### PR TITLE
Create the GenericMap type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # HEAD
 
 - Two new map projections: `orthographic2` and `gnomonic`
+- Make `Map` descend from the abstract type `GenericMap`
+  ([#12](https://github.com/ziotom78/Healpix.jl/pull/12))
 
 # Version 2.0.0
 

--- a/docs/src/mapfunc.md
+++ b/docs/src/mapfunc.md
@@ -31,7 +31,27 @@ mollweide(m * 2.0)
 mollweide(m * m)
 ```
 
+The [`Map{T, O <: Order}`](@ref) is derived from the abstract type
+[`GenericMap{T}`](@ref), which does not encode the ordering. It is useful for
+functions that can either work on ring/nested-ordered maps but cannot be
+executed on plain generic arrays:
+
+```julia
+# Return the number of pixels in the map, regardless of its ordering
+maplength(m::GenericMap{T}) where T = length(m)
+
+# This returns 12
+maplength(Map{Float64, RingOrder}(1))
+
+# This too returns 12
+maplength(Map{Float64, NestedOrder}(1))
+
+# This fails
+maplength(zeros(Float64, 12))
+```
+
 ```@docs
+GenericMap
 Map
 ```
 

--- a/src/Healpix.jl
+++ b/src/Healpix.jl
@@ -466,12 +466,29 @@ ordering. (See also `RingOrder`.)
 """
 abstract type NestedOrder <: Order end
 
-"""A Healpix map. The type `T` is used for the value of the pixels in
+"""
+    GenericMap{T} <: AbstractArray{T, 1}
+
+An abstract type representing an Healpix map without a specified
+ordering. This can be used to implement multiple dispatch when you
+don't care about the ordering of a map."""
+abstract type GenericMap{T} <: AbstractArray{T, 1}
+
+"""
+    struct Map{T, O <: Order} <: GenericMap{T}
+
+A Healpix map. The type `T` is used for the value of the pixels in
 a map, and it can be anything (even a string!). The type `O` is used
 to specify the ordering of the pixels, and it can either be
 `RingOrder` or `NestedOrder`.
+
+A `Map` type contains the following fields:
+
+- `pixels`: array of pixels
+- `resolution`: instance of a `Resolution` object
+
 """
-mutable struct Map{T, O <: Order} <: AbstractArray{T, 1}
+mutable struct Map{T, O <: Order} <: GenericMap{T}
     pixels::Array{T}
     resolution::Resolution
 

--- a/src/Healpix.jl
+++ b/src/Healpix.jl
@@ -472,7 +472,7 @@ abstract type NestedOrder <: Order end
 An abstract type representing an Healpix map without a specified
 ordering. This can be used to implement multiple dispatch when you
 don't care about the ordering of a map."""
-abstract type GenericMap{T} <: AbstractArray{T, 1}
+abstract type GenericMap{T} <: AbstractArray{T, 1} end
 
 """
     struct Map{T, O <: Order} <: GenericMap{T}

--- a/src/resolution.jl
+++ b/src/resolution.jl
@@ -3,9 +3,23 @@
 using Printf
 
 """
+    struct Resolution
+
 `Resolution` objects are needed to perform a number of pixel-related
 functions, e.g., convert a direction into a pixel number and vice
 versa.
+
+The fields of a `Resolution` object are the following:
+
+- `nside`: the NSIDE parameter
+- `nsideTimesTwo`: 2 * NSIDE
+- `nsideTimesFour`: 4 * NSIDE
+- `numOfPixels`: number of pixels in the map
+- `order`: order of the map
+- `pixelsPerFace`: number of pixels in each Healpix face
+- `ncap`
+- `fact2`
+- `fact1`
 """
 struct Resolution
     nside::Int


### PR DESCRIPTION
Currently, Healpix maps are derived from an AbstractArray type. This prevents users from defining functions that are specialized over Healpix maps, but which do not require a specific ordering (ring/nested).

This small PR introduces a new abstract type, `GenericMap{T}`, which is specialized by `Map{T,O}`. The following code shows how it should work:

```julia
import Healpix

# Return the number of pixels in the map, regardless of its ordering
f(m::Healpix.GenericMap{T}) where T = length(m)

# This returns 12
f(Healpix.Map{Float64, Healpix.RingOrder}(1))

# This too returns 12
f(Healpix.Map{Float64, Healpix.NestedOrder}(1))

# This fails
f(zeros(Float64, 12))
```

This widens the possibilities of using Julia's multiple dispatch with Healpix maps.