### PR TITLE
remove type annotations on SHT kwargs

### DIFF
--- a/src/sphtfunc.jl
+++ b/src/sphtfunc.jl
@@ -104,8 +104,8 @@ end
 
 """
     map2alm(map::Map{Float64, RingOrder}; 
-        lmax::Integer=nothing, mmax::Integer=nothing, niter::Integer=3)
-    map2alm(m::Map{T, RingOrder}; lmax::Integer=nothing, mmax::Integer=nothing, 
+        lmax=nothing, mmax=nothing, niter::Integer=3)
+    map2alm(m::Map{T, RingOrder}; lmax=nothing, mmax=nothing, 
         niter::Integer=3) where T <: Real
 
 Compute the spherical harmonic coefficients of a map. To enhance precision, more iterations
@@ -128,7 +128,7 @@ Float64.
 function map2alm end
 
 function map2alm(map::Map{Float64, RingOrder}; 
-        lmax::Integer=nothing, mmax::Integer=nothing, niter::Integer=3)
+        lmax=nothing, mmax=nothing, niter::Integer=3)
 
     nside = map.resolution.nside
     lmax = isnothing(lmax) ? 3 * nside - 1 : lmax
@@ -141,7 +141,7 @@ function map2alm(map::Map{Float64, RingOrder};
 end
 
 function map2alm(map::PolarizedMap{Float64, RingOrder};
-        lmax::Integer=nothing, mmax::Integer=nothing, niter::Integer=3)
+        lmax=nothing, mmax=nothing, niter::Integer=3)
 
     nside = map.i.resolution.nside
     lmax = isnothing(lmax) ? 3 * nside - 1 : lmax
@@ -156,15 +156,15 @@ function map2alm(map::PolarizedMap{Float64, RingOrder};
 end
 
 # convert maps to Float64
-function map2alm(map::Map{T, RingOrder}; lmax::Integer=nothing, mmax::Integer=nothing, 
+function map2alm(map::Map{T, RingOrder}; lmax=nothing, mmax=nothing, 
         niter::Integer=3) where T <: Real
     map_float = Map{Float64, RingOrder}(convert(Array{Float64,1}, map.pixels))
     return map2alm(map_float, lmax=lmax, mmax=mmax, niter=niter)
 end
 
 # convert PolarizedMap to Float64
-function map2alm(map::PolarizedMap{T, RingOrder}; lmax::Integer=nothing, 
-        mmax::Integer=nothing, niter::Integer=3) where T <: Real
+function map2alm(map::PolarizedMap{T, RingOrder}; lmax=nothing, mmax=nothing, 
+                 niter::Integer=3) where T <: Real
     m_i = convert(Array{Float64,1}, map.i)
     m_q = convert(Array{Float64,1}, map.q)
     m_u = convert(Array{Float64,1}, map.u)

--- a/test/test_sphtfunc.jl
+++ b/test/test_sphtfunc.jl
@@ -14,6 +14,10 @@ test_alm_spin0 = [
     0.00000000e+00,  0.00000000e+00, -7.87873039e-04-9.64866195e-20im]
 @test isapprox(alm.alm , test_alm_spin0)
 
+# test kwarg defaults
+@test isapprox(Healpix.map2alm(map).alm[1:2], 
+    [7.08915321e+00+0.0im, -3.33069318e-17+0.0im])
+
 ## test type convert
 map_int = Healpix.Map{Int64, Healpix.RingOrder}(
     2 .* ones(Int64,Healpix.nside2npix(nside)))


### PR DESCRIPTION
The kwargs shouldn't have the `::Integer` type annotation since the default argument of `nothing` is in `Union{Integer, Nothing}`. I've added a regression test.