### PR TITLE
fix type instability due to array dimension

### DIFF
--- a/src/alm.jl
+++ b/src/alm.jl
@@ -2,7 +2,7 @@
 
 "An array of a_ℓm numbers."
 mutable struct Alm{T <: Number}
-    alm::Array{T}
+    alm::Array{T, 1}
     lmax::Int
     mmax::Int
     tval::Int
@@ -12,7 +12,7 @@ mutable struct Alm{T <: Number}
                                                  mmax,
                                                  2lmax + 1)
 
-    function Alm{T}(lmax, mmax, arr::Array{T}) where {T <: Number}
+    function Alm{T}(lmax, mmax, arr::Array{T, 1}) where {T <: Number}
         (numberOfAlms(lmax, mmax) == length(arr)) || throw(DomainError())
 
         new{T}(arr, lmax, mmax, 2lmax + 1)

--- a/src/map.jl
+++ b/src/map.jl
@@ -41,7 +41,7 @@ A `Map` type contains the following fields:
 
 """
 mutable struct Map{T, O <: Order} <: GenericMap{T}
-    pixels::Array{T}
+    pixels::Array{T,1}
     resolution::Resolution
 
     """
@@ -55,7 +55,7 @@ mutable struct Map{T, O <: Order} <: GenericMap{T}
     """
     Create a map with the specified array of pixels.
     """
-    function Map{T, O}(arr::Array{T}) where {T, O <: Order}
+    function Map{T, O}(arr::Array{T,1}) where {T, O <: Order}
         nside = npix2nside(length(arr))
         new(arr, Resolution(nside))
     end


### PR DESCRIPTION
Allowing N-dimensional arrays without parametrizing on N can cause type instability, which was slowing down alm2cl (see Julia Performance Tips). Since Healpix arrays are always dimension 1 (as are the a_lm), there is no cost and free performance gains if one specifies the array dimension.