### PR TITLE
fix alm2cl bug and ctab

### DIFF
--- a/src/alm.jl
+++ b/src/alm.jl
@@ -114,10 +114,10 @@ function alm2cl(alm₁::Alm{Complex{T}}, alm₂::Alm{Complex{T}}) where {T <: Nu
     for l in 0:lmax
         for m in 1:l 
             index = almIndex(alm₁, l, m)
-            cl[l+1] += 2 * alm₁.alm[index] * conj(alm₂.alm[index])
+            cl[l+1] += 2 * real(alm₁.alm[index] * conj(alm₂.alm[index]))
         end
         index0 = almIndex(alm₁, l, 0)
-        cl[l+1] += alm₁.alm[index0] * conj(alm₂.alm[index0])
+        cl[l+1] += real(alm₁.alm[index0] * conj(alm₂.alm[index0]))
         cl[l+1] = cl[l+1] / (2 * l + 1)
     end
     return cl

--- a/src/xyf.jl
+++ b/src/xyf.jl
@@ -135,7 +135,7 @@ end
 
 function compress_bits(v::Int32)
     raw = (v & 0x5555) | ((v & 0x55550000) >> 15)
-    CTAB[raw & 0xff + 1] | (ctab[raw >> 8 + 1] << 4)
+    CTAB[raw & 0xff + 1] | (CTAB[raw >> 8 + 1] << 4)
 end
 
 function compress_bits(v::Int)


### PR DESCRIPTION
My unit tests were too nice and didn't introduce enough floating point error. Now alm2cl takes the real part of the inner product, to prevent InexactError.

Also I think there's a typo with capitalization in `ctab`.