### PR TITLE
add untyped constructor for PolarizedMap

### DIFF
--- a/docs/src/mapfunc.md
+++ b/docs/src/mapfunc.md
@@ -161,6 +161,14 @@ along some direction in the sky:
 interpolate
 ```
 
+## Upgrading and Downgrading
+Changing resolution is done with [`udgrade`](@ref). This is very fast for nested orderings,
+but slow for ring ordering.
+
+```@docs
+udgrade
+```
+
 ## Map-making
 
 Map-making is the process of converting a time series of measurements

--- a/src/Healpix.jl
+++ b/src/Healpix.jl
@@ -25,6 +25,8 @@ import FITSIO: FITS
 import Libsharp
 import Base: getindex, setindex!
 
+const UNSEEN = -1.6375e+30
+
 include("nside.jl")
 include("math.jl")
 include("datatables.jl")

--- a/src/map_pixelfunc.jl
+++ b/src/map_pixelfunc.jl
@@ -220,7 +220,7 @@ end
 
 
 """
-    udgrade(input_map::Map{T,O,AA}, output_nside) where {T,O,AA} -> Map{T,O,AA}
+    udgrade(input_map::Map{T,O,AA}, output_nside; kw...) where {T,O,AA} -> Map{T,O,AA}
 
 Upgrades or downgrades a map to a target nside. Always makes a copy. This is very fast 
 for nested orderings, but slow for ring because one needs to transform to nested ordering 
@@ -229,6 +229,11 @@ first.
 # Arguments:
 - `input_map::Map{T,O,AA}`: the map to upgrade/downgrade
 - `output_nside`: desired nside
+
+# Keywords:
+- `threshold=abs(1e-6UNSEEN)`: absolute tolerance for identifying a bad pixel vs UNSEEN
+- `pess=false`: if false, estimate pixels from remaining good pixels when downgrading. 
+    if true, the entire downgraded pixel is set to UNSEEN.
 
 # Returns: 
 - `Map{T,O,AA}`: upgraded/downgraded map in the same ordering as the input

--- a/src/map_pixelfunc.jl
+++ b/src/map_pixelfunc.jl
@@ -216,3 +216,83 @@ function ring2nest!(m_nest_dst::Map{T, NestedOrder, AAN}, m_ring_src::Map{T, Rin
         m_nest_dst.pixels[i_nest] = m_ring_src.pixels[i_ring]
     end
 end
+
+
+
+"""
+    udgrade(input_map::Map{T,O,AA}, output_nside) where {T,O,AA} -> Map{T,O,AA}
+
+Upgrades or downgrades a map to a target nside. Always makes a copy. This is very fast 
+for nested orderings, but slow for ring because one needs to transform to nested ordering 
+first.
+
+# Arguments:
+- `input_map::Map{T,O,AA}`: the map to upgrade/downgrade
+- `output_nside`: desired nside
+
+# Returns: 
+- `Map{T,O,AA}`: upgraded/downgraded map
+
+# Examples
+```julia-repl
+julia> A = Map{Float64, NestedOrder}(ones(nside2npix(4)))
+192-element Map{Float64, RingOrder, Vector{Float64}}:
+ 1.0
+ ⋮
+ 1.0
+
+julia> Healpix.udgrade(A, 2)
+48-element Map{Float64, NestedOrder, Vector{Float64}}:
+ 1.0
+ ⋮
+ 1.0
+```
+"""
+function udgrade(map_in::Map{T,O,AA}, nside_out; 
+                 threshold=abs(1e-6UNSEEN), pess=false) where {T,O<:NestedOrder,AA}
+    nside_in = map_in.resolution.nside
+    npix_out = nside2npix(nside_out)
+    map_out = Map{T,O,AA}(nside_out)
+
+    if nside_in == nside_out
+        map_out.pixels .= input_map.pixels
+    elseif nside_out < nside_in  # degrade. loop over input and add them up 
+        npratio = nside2npix(nside_in) ÷ nside2npix(nside_out)
+        for id = 0:(npix_out-1)
+            nobs = 0
+            total = 0.0
+            for ip = 0:(npratio-1)
+                value = map_in[id*npratio + ip + 1]
+                if (abs(value - UNSEEN) > threshold) 
+                    nobs  = nobs  + 1
+                    total = total + value
+                end
+            end
+            map_out[id+1] = UNSEEN
+            if pess
+                if nobs == npratio
+                    map_out[id+1] = total/nobs
+                end
+            else
+                if nobs > 0
+                    map_out[id+1] = total/nobs
+                end
+            end
+        end
+    else  # we are upgrading. loop over output map pixels, and set them to parent pixel
+        npratio = nside2npix(nside_out) ÷ nside2npix(nside_in)
+        for iu = 0:(npix_out - 1)
+            ip = iu ÷ npratio
+            map_out[iu+1] = map_in[ip+1]
+        end
+    end
+
+    return map_out
+end
+# just convert to nest and udgrade if we get a ring
+function udgrade(map_in::Map{T,O,AA}, nside_out; 
+                 threshold=abs(1e-6UNSEEN), pess=true) where {T,O<:RingOrder,AA}
+    map_nest = ring2nest(map_in)
+    map_out = udgrade(map_nest, nside_out; threshold=threshold, pess=pess)
+    return nest2ring(map_out)
+end

--- a/src/map_pixelfunc.jl
+++ b/src/map_pixelfunc.jl
@@ -231,7 +231,7 @@ first.
 - `output_nside`: desired nside
 
 # Returns: 
-- `Map{T,O,AA}`: upgraded/downgraded map
+- `Map{T,O,AA}`: upgraded/downgraded map in the same ordering as the input
 
 # Examples
 ```julia-repl

--- a/src/map_pixelfunc.jl
+++ b/src/map_pixelfunc.jl
@@ -260,7 +260,7 @@ function udgrade(map_in::Map{T,O,AA}, nside_out;
     map_out = Map{T,O,AA}(nside_out)
 
     if nside_in == nside_out
-        map_out.pixels .= input_map.pixels
+        map_out.pixels .= map_in.pixels
     elseif nside_out < nside_in  # degrade. loop over input and add them up 
         npratio = nside2npix(nside_in) ÷ nside2npix(nside_out)
         for id = 0:(npix_out-1)

--- a/src/polarizedmap.jl
+++ b/src/polarizedmap.jl
@@ -66,3 +66,12 @@ end
 function PolarizedMap{T,O}(i::Array{T,1}, q::Array{T,1}, u::Array{T,1}) where {T,O<:Order}
     PolarizedMap{T,O,Array{T,1}}(i, q, u)
 end
+
+
+function PolarizedMap(
+    i::Map{T,O,AA},
+    q::Map{T,O,AA},
+    u::Map{T,O,AA},
+) where {T,O<:Order,AA<:AbstractArray{T,1}}
+    return PolarizedMap{T,O,AA}(i, q, u)
+end

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -15,7 +15,6 @@ export UNSEEN,
 
 import RecipesBase
 
-const UNSEEN = -1.6375e+30
 
 """
     project(invprojfn, m::Map{T, O, AA}, bmpwidth, bmpheight; kwargs...)

--- a/test/test_pixelfunctions.jl
+++ b/test/test_pixelfunctions.jl
@@ -2037,3 +2037,23 @@ end
     @test z ≈ -0.1666666666667
     @test phi ≈ 5.497787143782
 end
+
+
+## Test udgrade
+A = Healpix.Map{Float64, Healpix.NestedOrder}(1.0:Healpix.nside2npix(4))
+nest_ref = [8.5,24.5,40.5,56.5,72.5,88.5,104.5,120.5,136.5,152.5,168.5,184.5]
+@test Healpix.udgrade(A, 1).pixels ≈ nest_ref
+@test Healpix.udgrade(A, 8).pixels ≈ repeat(A.pixels, inner=4)
+
+ring_ref = [30.0625,33.4375,36.8125,40.1875,94.75,92.75,96.75,100.75,153.0625,156.4375,
+    159.8125,163.1875]
+A = Healpix.Map{Float64, Healpix.RingOrder}(1.0:Healpix.nside2npix(4))
+@test Healpix.udgrade(A, 1).pixels ≈ ring_ref
+
+
+unseen_ref = [9.0,24.5,40.5,56.5,72.5,88.5,104.5,120.5,136.5,152.5,168.5,184.5]
+A = Healpix.Map{Float64, Healpix.NestedOrder}(1.0:Healpix.nside2npix(4))
+A[1] = Healpix.UNSEEN
+Healpix.udgrade(A, 1).pixels
+@test Healpix.udgrade(A, 1).pixels ≈ unseen_ref
+@test Healpix.udgrade(A, 1; pess=true) ≈ [Healpix.UNSEEN, unseen_ref[2:end]...]

--- a/test/test_pixelfunctions.jl
+++ b/test/test_pixelfunctions.jl
@@ -2057,3 +2057,5 @@ A[1] = Healpix.UNSEEN
 Healpix.udgrade(A, 1).pixels
 @test Healpix.udgrade(A, 1).pixels ≈ unseen_ref
 @test Healpix.udgrade(A, 1; pess=true) ≈ [Healpix.UNSEEN, unseen_ref[2:end]...]
+
+@test A ≈ Healpix.udgrade(A, 4)

--- a/test/test_polarizedmap.jl
+++ b/test/test_polarizedmap.jl
@@ -8,6 +8,14 @@ polmap =
 @test polmap.q == pixels_nside1
 @test polmap.u == pixels_nside1
 
+
+# test the untyped constructor
+polmap_new = Healpix.PolarizedMap(polmap.i, polmap.q, polmap.u)
+@test polmap.i == polmap_new.i
+@test polmap.q == polmap_new.q
+@test polmap.u == polmap_new.u
+
+
 polmap = Healpix.PolarizedMap{Int8,Healpix.RingOrder}(128)
 
 @test length(polmap.i) == length(polmap.q) == length(polmap.u)


### PR DESCRIPTION
The docstring suggests you can create a PolarizedMap with

```julia
PolarizedMap(i, q, u)
```
when `i`, `q`, and `u` are 
```julia
Map{T,O,AA}, q::Map{T,O,AA}, u::Map{T,O,AA}
```
since the type of the PolarizedMap is inferrable from the inputs. This PR adds that constructor.