### PR TITLE
add untyped constructor for PolarizedMap

### DIFF
--- a/src/polarizedmap.jl
+++ b/src/polarizedmap.jl
@@ -66,3 +66,11 @@ end
 function PolarizedMap{T,O}(i::Array{T,1}, q::Array{T,1}, u::Array{T,1}) where {T,O<:Order}
     PolarizedMap{T,O,Array{T,1}}(i, q, u)
 end
+
+function PolarizedMap(
+    i::Map{T,O,AA},
+    q::Map{T,O,AA},
+    u::Map{T,O,AA},
+) where {T,O<:Order,AA<:AbstractArray{T,1}}
+    return PolarizedMap{T,O,AA}(i, q, u)
+end

--- a/test/test_polarizedmap.jl
+++ b/test/test_polarizedmap.jl
@@ -8,6 +8,12 @@ polmap =
 @test polmap.q == pixels_nside1
 @test polmap.u == pixels_nside1
 
+# test the untyped constructor
+polmap_new = Healpix.PolarizedMap(polmap.i, polmap.q, polmap.u)
+@test polmap.i == polmap_new.i
+@test polmap.q == polmap_new.q
+@test polmap.u == polmap_new.u
+
 polmap = Healpix.PolarizedMap{Int8,Healpix.RingOrder}(128)
 
 @test length(polmap.i) == length(polmap.q) == length(polmap.u)


### PR DESCRIPTION
The docstring suggests you can create a PolarizedMap with

```julia
PolarizedMap(i, q, u)
```
when `i`, `q`, and `u` are 
```julia
Map{T,O,AA}, q::Map{T,O,AA}, u::Map{T,O,AA}
```
since the type of the PolarizedMap is inferrable from the inputs. This PR adds that constructor.

(I closed a similar PR due to some a mistake with git where I branched off of the udgrade branch instead of master.