### PR TITLE
rename applyweights! and add artifact downloading

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,3 +4,29 @@ git-tree-sha1 = "d11923cfa0b2d87d5bb8898ea574b8a9b2a114fc"
     [[pixwin.download]]
     url = "https://github.com/xzackli/HEALPix_data/raw/master/pixwin.tar.gz"
     sha256 = "986792ca52a53d8cf34b2e0fa18d5c1a9aebdfd0167edfb1fc472daf1965ab07"
+
+
+[fullpixelweights_32_2048]
+git-tree-sha1 = "f226f79884e8afcdaf3c42d90aac01db48110e50"
+lazy = true
+
+    [[fullpixelweights_32_2048.download]]
+    url = "https://github.com/xzackli/HEALPix_data/releases/download/0.1/healpix_full_weights_nside_32_2048.tar.gz"
+    sha256 = "f1d8eeb1b575c9684c2fcfd9ff35df086f19f48bb3e9272b1ac3493ed27fd632"
+
+[fullpixelweights_4096]
+git-tree-sha1 = "22994e088fd2b42ecdb891e50a189a4c11ce462d"
+lazy = true
+
+    [[fullpixelweights_4096.download]]
+    url = "https://github.com/xzackli/HEALPix_data/releases/download/0.1/healpix_full_weights_nside_4096.tar.gz"
+    sha256 = "f2d29874de71a7aa2372238e42d4a1446705b2162756d07fc50505292b8da5a2"
+
+
+[fullpixelweights_8192]
+git-tree-sha1 = "c297f7926b934e304936a19bd0f46f9772b9ca8d"
+lazy = true
+
+    [[fullpixelweights_8192.download]]
+    url = "https://github.com/xzackli/HEALPix_data/releases/download/0.1/healpix_full_weights_nside_8192.tar.gz"
+    sha256 = "78fc7426467f314bf498700b803d33dcedde21f67992b03f0ed3e53b1e0ab6cb"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "2.3.0"
 
 [deps]
 CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Libsharp = "ac8d63fe-4615-43ae-9860-9cd4a3820532"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/docs/src/alm.md
+++ b/docs/src/alm.md
@@ -106,14 +106,14 @@ git clone --depth 1 https://github.com/healpy/healpy-data
 ```
 
 These weights are in a compressed format that is read with [`readfullweights`](@ref)
-and multiplied into a map with [`applyweights!`](@ref). 
+and multiplied into a map with [`applyfullweights!`](@ref). 
 
 ```julia
 nside = 32
 compressed_weights = Healpix.readfullweights(
     "healpix_full_weights_nside_$(lpad(nside,4,'0')).fits")
 m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
-Healpix.applyweights!(m, compressed_weights)
+Healpix.applyfullweights!(m, compressed_weights)
 alm = Healpix.map2alm(m; niter=0)
 ```
 
@@ -121,5 +121,5 @@ The subsequent [`map2alm`](@ref) only needs `niter=0`.
 
 ```@docs
 Healpix.readfullweights
-Healpix.applyweights!
+Healpix.applyfullweights!
 ```

--- a/src/Healpix.jl
+++ b/src/Healpix.jl
@@ -17,7 +17,7 @@ export pix2xyfRing, xyf2pixRing, pix2xyfNest, xyf2pixNest
 export pix2zphiNest, pix2zphiRing, ringAbove
 export ring2nest, nest2ring, ring2nest!, nest2ring!, udgrade
 
-using Pkg.Artifacts
+using LazyArtifacts
 import CFITSIO
 
 import Libsharp

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -43,17 +43,20 @@ function readfullweights(filename::String)
 end
 
 """
-    applyweights!(m::Map{T, RingOrder}, wgt::Vector{T}) where T
+    applyfullweights!(m::Map{T, RingOrder}, [wgt::Vector{T}]) where T
 
 Apply a pixel weighting to a map for more accurate SHTs. Note that 
 this only helps for `lmax<=1.5*Nside`. If this is not the case, the 
 pixel weights may do more harm than good.
 
+Pixel weights are automatically downloaded if not specified. 
+
 # Arguments:
 - `m::Map{T, RingOrder}`: map to modify
-- `wgt::Vector{T}`: compressed pixel weights
+- `wgt::Vector{T}` (optional): compressed pixel weights. If not specified, this routine will
+    look for weights in artifacts.
 """
-function applyweights!(m::Map{T,RingOrder}, wgt::Vector{T}) where T
+function applyfullweights!(m::Map{T,RingOrder}, wgt::Vector{T}) where T
     nside = m.resolution.nside
     @assert length(wgt) == n_fullweights(nside)
     pix, vpix = 0, 0
@@ -74,12 +77,31 @@ function applyweights!(m::Map{T,RingOrder}, wgt::Vector{T}) where T
         end
         pix += qpix << 2;
         vpix += wpix;
+    end
 end
+
+
+function applyfullweights!(m::Map{T,RingOrder}) where T
+    nside = m.resolution.nside
+    
+    if nside ∈ (32, 64, 128, 256, 512, 1024, 2048)
+        path = artifact"fullpixelweights_32_2048"
+    elseif nside == 4096
+        path = artifact"fullpixelweights_4096"
+    elseif nside == 8192
+        path = artifact"fullpixelweights_8192"
+    else
+        throw(ArgumentError("Unsupported nside $(nside)"))
+    end
+
+    nside_str = lpad(nside, 4, '0')
+    wgt = readfullweights(joinpath(path, "healpix_full_weights_nside_$(nside_str).fits"))
+    applyfullweights!(m, wgt)
 end
 
 
 """
-    applyweights!(m::PolarizedMap{T, RingOrder}, wgt::Vector{T}) where T
+    applyfullweights!(m::PolarizedMap{T, RingOrder}, wgt::Vector{T}) where T
 
 Apply a pixel weighting to a polarized map for more accurate SHTs.
 
@@ -87,8 +109,8 @@ Apply a pixel weighting to a polarized map for more accurate SHTs.
 - `m::PolarizedMap{T, RingOrder}`: map to modify
 - `wgt::Vector{T}`: compressed pixel weights
 """
-function applyweights!(m::PolarizedMap{T,RingOrder}, wgt::Vector{T}) where T
-    applyweights!(m.i, wgt)
-    applyweights!(m.q, wgt)
-    applyweights!(m.u, wgt)
+function applyfullweights!(m::PolarizedMap{T,RingOrder}, wgt::Vector{T}) where T
+    applyfullweights!(m.i, wgt)
+    applyfullweights!(m.q, wgt)
+    applyfullweights!(m.u, wgt)
 end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -101,16 +101,22 @@ end
 
 
 """
-    applyfullweights!(m::PolarizedMap{T, RingOrder}, wgt::Vector{T}) where T
+    applyfullweights!(m::PolarizedMap{T, RingOrder}, [wgt::Vector{T}]) where T
 
 Apply a pixel weighting to a polarized map for more accurate SHTs.
 
 # Arguments:
 - `m::PolarizedMap{T, RingOrder}`: map to modify
-- `wgt::Vector{T}`: compressed pixel weights
+- `wgt::Vector{T}` (optional): compressed pixel weights. If not specified, an artifact 
+        will be sought.
 """
 function applyfullweights!(m::PolarizedMap{T,RingOrder}, wgt::Vector{T}) where T
     applyfullweights!(m.i, wgt)
     applyfullweights!(m.q, wgt)
     applyfullweights!(m.u, wgt)
+end
+function applyfullweights!(m::PolarizedMap{T,RingOrder}) where T
+    applyfullweights!(m.i)
+    applyfullweights!(m.q)
+    applyfullweights!(m.u)
 end

--- a/test/test_sphtfunc.jl
+++ b/test/test_sphtfunc.jl
@@ -338,7 +338,7 @@ testcl = [
 nside = 32
 compressed_weights = Healpix.readfullweights("healpix_full_weights_nside_$(lpad(nside,4,'0')).fits")
 m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
-Healpix.applyweights!(m, compressed_weights)
+Healpix.applyfullweights!(m, compressed_weights)
 alm = Healpix.map2alm(m; niter=0)
 ref_alm = [
     3.5449077018110313 + 0.0im,
@@ -354,6 +354,13 @@ ref_alm = [
 ]
 @test isapprox(alm.alm[1:10], ref_alm)
 
+# test artifact 
+m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
+Healpix.applyfullweights!(m)
+alm = Healpix.map2alm(m; niter=0)
+@test isapprox(alm.alm[1:10], ref_alm)
+
+
 ## test polarized map pixel weights
 nside = 32
 npix = Healpix.nside2npix(nside)
@@ -361,7 +368,7 @@ m = Healpix.PolarizedMap{Float64, Healpix.RingOrder}(
     1.0 .* collect(1:npix), 
     1.0 .* collect(1:npix), 
     1.0 .* collect(1:npix))
-Healpix.applyweights!(m, compressed_weights)
+Healpix.applyfullweights!(m, compressed_weights)
 t, e, b = Healpix.map2alm(m; niter=0)
 
 @test t.alm[1:10] ≈ [ 2.17816852e+04, -1.25746386e+04, -4.78882357e-05,

--- a/test/test_sphtfunc.jl
+++ b/test/test_sphtfunc.jl
@@ -371,18 +371,31 @@ m = Healpix.PolarizedMap{Float64, Healpix.RingOrder}(
 Healpix.applyfullweights!(m, compressed_weights)
 t, e, b = Healpix.map2alm(m; niter=0)
 
-@test t.alm[1:10] ≈ [ 2.17816852e+04, -1.25746386e+04, -4.78882357e-05,
+ref_t = [ 2.17816852e+04, -1.25746386e+04, -4.78882357e-05,
     8.06798732e-13,  2.26897086e-04,  7.63539583e-13,
     -3.55340635e-05,  1.72723033e-12, -2.30114092e-04,
     7.65480933e-12]
-@test e.alm[1:10] ≈ [     0.        ,      0.        , -19883.86722869,
+ref_e = [     0.        ,      0.        , -19883.86722869,
     10520.69745406,  -6887.97347407,   4984.74371257,
     -3832.11490208,   3067.89767865,  -2530.0593288 ,
     2133.53781326]
-@test b.alm[1:10] ≈ [     0.        ,      0.        , -19883.86722869,
+ref_b = [     0.        ,      0.        , -19883.86722869,
     10520.69745406,  -6887.97347407,   4984.74371257,
     -3832.11490208,   3067.89767865,  -2530.0593288 ,
     2133.53781326]
+@test t.alm[1:10] ≈ ref_t
+@test e.alm[1:10] ≈ ref_e
+@test b.alm[1:10] ≈ ref_b
+
+m = Healpix.PolarizedMap{Float64, Healpix.RingOrder}(
+    1.0 .* collect(1:npix), 
+    1.0 .* collect(1:npix), 
+    1.0 .* collect(1:npix))
+Healpix.applyfullweights!(m)
+t, e, b = Healpix.map2alm(m; niter=0)
+@test t.alm[1:10] ≈ ref_t
+@test e.alm[1:10] ≈ ref_e
+@test b.alm[1:10] ≈ ref_b
 
 
 ## test pixel window function


### PR DESCRIPTION
This downloads the full pixel weights via artifact if the file is not specified. I also renamed it to `applyfullweights!` from `applyweights!` because the single argument call looked confusing since the weights were not part of the call anymore.

### Syntax
```julia
m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
Healpix.applyfullweights!(m)  # this (lazy) downloads the full pixel weights
alm = Healpix.map2alm(m; niter=0)
```

The pixel weights are separated into three separate artifacts. nside 32 to 2048 are bundled, and then 4096 and 8192 are each separate because they're much larger.
