### PR TITLE
Global rename

### DIFF
--- a/docs/src/alm.md
+++ b/docs/src/alm.md
@@ -15,7 +15,7 @@ computation of convolution operators.
 
 Everything revolves around the [`Alm`](@ref) type, which encodes a set of
 spherical harmonics and is thus conceptually equivalent to the concept
-of a [`Map`](@ref), only living in the harmonic space:
+of a [`HealpixMap`](@ref), only living in the harmonic space:
 
 ```@docs
 Alm
@@ -54,7 +54,7 @@ using Random
 Random.seed!(1234)
 
 nside = 8
-m = Map{Float32,RingOrder}(nside)
+m = HealpixMap{Float32,RingOrder}(nside)
 
 # Initialize the pixels to random values in the 0…1 range
 for i in 1:length(m)
@@ -112,7 +112,7 @@ and multiplied into a map with [`applyweights!`](@ref).
 nside = 32
 compressed_weights = Healpix.readfullweights(
     "healpix_full_weights_nside_$(lpad(nside,4,'0')).fits")
-m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
+m = Healpix.HealpixMap{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
 Healpix.applyweights!(m, compressed_weights)
 alm = Healpix.map2alm(m; niter=0)
 ```

--- a/docs/src/mapfunc.md
+++ b/docs/src/mapfunc.md
@@ -32,13 +32,13 @@ mollweide(m * m)
 ```
 
 The [`Map{T, O <: Order}`](@ref) is derived from the abstract type
-[`GenericMap{T}`](@ref), which does not encode the ordering. It is useful for
+[`AbstractHealpixMap{T}`](@ref), which does not encode the ordering. It is useful for
 functions that can either work on ring/nested-ordered maps but cannot be
 executed on plain generic arrays:
 
 ```julia
 # Return the number of pixels in the map, regardless of its ordering
-maplength(m::GenericMap{T}) where T = length(m)
+maplength(m::AbstractHealpixMap{T}) where T = length(m)
 
 # This returns 12
 maplength(Map{Float64, RingOrder}(1))
@@ -56,7 +56,7 @@ intensity (I), and the Q and U Stokes parameters. The three maps must
 have the same resolution.
 
 ```@docs
-GenericMap
+AbstractHealpixMap
 Map
 PolarizedMap
 ```

--- a/docs/src/mapfunc.md
+++ b/docs/src/mapfunc.md
@@ -10,15 +10,15 @@ Functions like [`pix2angNest`](@ref) and [`ang2pixNest`](@ref) fully
 define the Healpix tessellation scheme. They are however extremely
 impractical in a number of situations. It happens often that a large
 fraction of pixels in a map need to be processed together. Healpix.jl
-introduces the [`Map{T, O <: Order}`](@ref) type, which acts as a
-collection of all the pixels on the sphere. A `Map` type holds the
+introduces the [`HealpixMap{T, O <: Order}`](@ref) type, which acts as a
+collection of all the pixels on the sphere. A `HealpixMap` type holds the
 value of all the pixels in its `pixels` field, and it keeps track of
 the ordering (either `RING` or `NESTED`). Here is an example that
 shows how to create a map and initialize it:
 
 ```julia
 nside = 32
-m = Map{Float64, RingOrder}(nside)
+m = HealpixMap{Float64, RingOrder}(nside)
 m.pixels[:] = 1.0  # Set all pixels to 1
 ```
 
@@ -31,34 +31,35 @@ mollweide(m * 2.0)
 mollweide(m * m)
 ```
 
-The [`Map{T, O <: Order}`](@ref) is derived from the abstract type
-[`AbstractHealpixMap{T}`](@ref), which does not encode the ordering. It is useful for
-functions that can either work on ring/nested-ordered maps but cannot be
-executed on plain generic arrays:
+The [`HealpixMap{T, O <: Order}`](@ref) is derived from the abstract
+type [`AbstractHealpixMap{T}`](@ref), which does not encode the
+ordering. It is useful for functions that can either work on
+ring/nested-ordered maps but cannot be executed on plain generic
+arrays:
 
 ```julia
 # Return the number of pixels in the map, regardless of its ordering
 maplength(m::AbstractHealpixMap{T}) where T = length(m)
 
 # This returns 12
-maplength(Map{Float64, RingOrder}(1))
+maplength(HealpixMap{Float64, RingOrder}(1))
 
 # This too returns 12
-maplength(Map{Float64, NestedOrder}(1))
+maplength(HealpixMap{Float64, NestedOrder}(1))
 
 # This fails
 maplength(zeros(Float64, 12))
 ```
 
-Healpix.jl implements the [`PolarizedMap{T, O <: Order}`](@ref) type
+Healpix.jl implements the [`PolarizedHealpixMap{T, O <: Order}`](@ref) type
 as well. This encodes three maps containing the I/Q/U signal: the
 intensity (I), and the Q and U Stokes parameters. The three maps must
 have the same resolution.
 
 ```@docs
 AbstractHealpixMap
-Map
-PolarizedMap
+HealpixMap
+PolarizedHealpixMap
 ```
 
 ## Encoding the order
@@ -66,7 +67,7 @@ PolarizedMap
 Healpix.jl distinguishes between `RING` and `NEST` orderings using
 Julia's typesystem. The abstract type `Order` has two descendeants,
 `RingOrder` and `NestedOrder`, which are used to instantiate objects
-of type `Map`. Applying the functions [`nest2ring`](@ref) and 
+of type `HealpixMap`. Applying the functions [`nest2ring`](@ref) and 
 [`ring2nest`](@ref) to maps converts those maps to the appropriate orders.
 In-place [`nest2ring!`](@ref) and [`ring2nest!`](@ref) versions are also 
 available.
@@ -75,12 +76,12 @@ available.
 Order
 RingOrder
 NestedOrder
-nest2ring(m_nest::Map{T, NestedOrder, AA}) where {T, AA}
-ring2nest(m_ring::Map{T, RingOrder, AA}) where {T, AA}
-nest2ring!(m_ring_dst::Map{T, RingOrder, AAR}, 
-  m_nest_src::Map{T, NestedOrder, AAN}) where {T, AAN, AAR}
-ring2nest!(m_nest_dst::Map{T, NestedOrder, AAN}, 
-  m_ring_src::Map{T, RingOrder, AAR}) where {T, AAR, AAN}
+nest2ring(m_nest::HealpixMap{T, NestedOrder, AA}) where {T, AA}
+ring2nest(m_ring::HealpixMap{T, RingOrder, AA}) where {T, AA}
+nest2ring!(m_ring_dst::HealpixMap{T, RingOrder, AAR}, 
+  m_nest_src::HealpixMap{T, NestedOrder, AAN}) where {T, AAN, AAR}
+ring2nest!(m_nest_dst::HealpixMap{T, NestedOrder, AAN}, 
+  m_ring_src::HealpixMap{T, RingOrder, AAR}) where {T, AAR, AAN}
 ```
 
 
@@ -88,9 +89,9 @@ ring2nest!(m_nest_dst::Map{T, NestedOrder, AAN},
 ## Pixel functions
 
 When working with maps, it is not needed to pick between
-[`ang2pixNest`](@ref) and [`ang2pixRing`](@ref) because a `Map` type
+[`ang2pixNest`](@ref) and [`ang2pixRing`](@ref) because a `HealpixMap` type
 already encodes the ordering. Functions `pix2ang` and `ang2pix` always
-choose the correct ordering, but they require a `Map` instead of a
+choose the correct ordering, but they require a `HealpixMap` instead of a
 [`Resolution`](@ref) as their first argument.
 
 ```@docs
@@ -131,10 +132,10 @@ conversions. The function `conformables` checks this.
 
 ```@repl
 using Healpix # hide
-m1 = Map{Float64, RingOrder}(1)
-m2 = Map{Float64, RingOrder}(1)
-m3 = Map{Float64, NestedOrder}(1)
-m4 = Map{Float64, NestedOrder}(2)
+m1 = HealpixMap{Float64, RingOrder}(1)
+m2 = HealpixMap{Float64, RingOrder}(1)
+m3 = HealpixMap{Float64, NestedOrder}(1)
+m4 = HealpixMap{Float64, NestedOrder}(2)
 conformables(m1, m2)
 conformables(m1, m3)
 conformables(m1, m4)

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -13,7 +13,7 @@ using Plots
 gr()  # Use the GR backend
 
 nside = 8
-m = Map{Float64, RingOrder}(nside)
+m = HealpixMap{Float64, RingOrder}(nside)
 m.pixels[:] = 1:length(m.pixels)
 plot(m)
 savefig(joinpath("images", "mollweide.png")) # hide
@@ -65,7 +65,7 @@ Consider this example:
 ```@example project
 using Healpix
 
-m = Map{Float64, RingOrder}(1)
+m = HealpixMap{Float64, RingOrder}(1)
 # Plot the map on a 20×20 bitmap using an
 # equirectangular projection
 image, mask, maskflag = project(equiprojinv, m, 20, 20)

--- a/src/Healpix.jl
+++ b/src/Healpix.jl
@@ -5,7 +5,7 @@ export Resolution, nside2npix, npix2nside
 export ang2pixNest, ang2pixRing, pix2angNest, pix2angRing
 export vec2pixNest, vec2pixRing, pix2vecNest, pix2vecRing
 export pix2ringpos
-export Order, RingOrder, NestedOrder, GenericMap, Map, PolarizedMap
+export Order, RingOrder, NestedOrder, AbstractHealpixMap, Map, PolarizedMap
 export ang2vec, vec2ang, ang2pix, pix2ang
 export readMapFromFITS, savePixelsToFITS, saveToFITS, conformables
 export ringWeightPath, readWeightRing

--- a/src/Healpix.jl
+++ b/src/Healpix.jl
@@ -5,7 +5,7 @@ export Resolution, nside2npix, npix2nside
 export ang2pixNest, ang2pixRing, pix2angNest, pix2angRing
 export vec2pixNest, vec2pixRing, pix2vecNest, pix2vecRing
 export pix2ringpos
-export Order, RingOrder, NestedOrder, AbstractHealpixMap, Map, PolarizedMap
+export Order, RingOrder, NestedOrder, AbstractHealpixMap, HealpixMap, PolarizedHealpixMap
 export ang2vec, vec2ang, ang2pix, pix2ang
 export readMapFromFITS, savePixelsToFITS, saveToFITS, conformables
 export ringWeightPath, readWeightRing

--- a/src/conformables.jl
+++ b/src/conformables.jl
@@ -1,37 +1,37 @@
 ################################################################################
 
-conformables(map1::Map{T,RingOrder,AA1}, map2::Map{S,RingOrder,AA2}) where {T,S,AA1,AA2} =
+conformables(map1::HealpixMap{T,RingOrder,AA1}, map2::HealpixMap{S,RingOrder,AA2}) where {T,S,AA1,AA2} =
     map1.resolution.nside == map2.resolution.nside
 
 conformables(
-    map1::Map{T,NestedOrder,AA1},
-    map2::Map{S,NestedOrder,AA2},
+    map1::HealpixMap{T,NestedOrder,AA1},
+    map2::HealpixMap{S,NestedOrder,AA2},
 ) where {T,S,AA1,AA2} = map1.resolution.nside == map2.resolution.nside
 
-conformables(map1::Map{T,O1,AA1}, map2::Map{S,O2,AA2}) where {T,S,O1,O2,AA1,AA2} = false
+conformables(map1::HealpixMap{T,O1,AA1}, map2::HealpixMap{S,O2,AA2}) where {T,S,O1,O2,AA1,AA2} = false
 
 ################################################################################
 
 conformables(
-    map1::PolarizedMap{T,RingOrder,AA1},
-    map2::PolarizedMap{S,RingOrder,AA2},
+    map1::PolarizedHealpixMap{T,RingOrder,AA1},
+    map2::PolarizedHealpixMap{S,RingOrder,AA2},
 ) where {T,S,AA1,AA2} = map1.i.resolution.nside == map2.i.resolution.nside
 
 conformables(
-    map1::PolarizedMap{T,NestedOrder,AA1},
-    map2::PolarizedMap{S,NestedOrder,AA2},
+    map1::PolarizedHealpixMap{T,NestedOrder,AA1},
+    map2::PolarizedHealpixMap{S,NestedOrder,AA2},
 ) where {T,S,AA1,AA2} = map1.i.resolution.nside == map2.i.resolution.nside
 
 conformables(
-    map1::PolarizedMap{T,O1,AA1},
-    map2::PolarizedMap{S,O2,AA2},
+    map1::PolarizedHealpixMap{T,O1,AA1},
+    map2::PolarizedHealpixMap{S,O2,AA2},
 ) where {T,S,O1,O2,AA1,AA2} = false
 
 """
-    conformables{T, S, O1, O2}(map1::Map{T, O1, AA1},
-                               map2::Map{S, O2, AA2}) -> Bool
-    conformables{T, S, O1, O2}(map1::PolarizedMap{T, O1, AA1},
-                               map2::PolarizedMap{S, O2, AA2}) -> Bool
+    conformables{T, S, O1, O2}(map1::HealpixMap{T, O1, AA1},
+                               map2::HealpixMap{S, O2, AA2}) -> Bool
+    conformables{T, S, O1, O2}(map1::PolarizedHealpixMap{T, O1, AA1},
+                               map2::PolarizedHealpixMap{S, O2, AA2}) -> Bool
 
 Determine if two Healpix maps are "conformables", i.e., if their shape
 and ordering are the same. The array types `AA1` and `AA2` are not considered

--- a/src/map.jl
+++ b/src/map.jl
@@ -19,15 +19,15 @@ ordering. (See also `RingOrder`.)
 abstract type NestedOrder <: Order end
 
 """
-    GenericMap{T} <: AbstractArray{T, 1}
+    AbstractHealpixMap{T} <: AbstractArray{T, 1}
 
 An abstract type representing an Healpix map without a specified
 ordering. This can be used to implement multiple dispatch when you
 don't care about the ordering of a map."""
-abstract type GenericMap{T} <: AbstractArray{T,1} end
+abstract type AbstractHealpixMap{T} <: AbstractArray{T,1} end
 
 """
-    struct Map{T, O <: Order, AA <: AbstractArray{T, 1}} <: GenericMap{T}
+    struct Map{T, O <: Order, AA <: AbstractArray{T, 1}} <: AbstractHealpixMap{T}
 
 A Healpix map. The type `T` is used for the value of the pixels in a
 map, and it can be anything (even a string!). The type `O` is used to
@@ -73,7 +73,7 @@ Finally, the following examples show how to use `SharedArray`:
     pixels = SharedArray{Int64, 1}(1:12 |> collect)
     mymap = Healpix.Map{Int64, Healpix.RingOrder, SharedArray{Int64, 1}}(m)
 """
-mutable struct Map{T,O<:Order,AA<:AbstractArray{T,1}} <: GenericMap{T}
+mutable struct Map{T,O<:Order,AA<:AbstractArray{T,1}} <: AbstractHealpixMap{T}
     pixels::AA
     resolution::Resolution
 

--- a/src/map.jl
+++ b/src/map.jl
@@ -1,18 +1,18 @@
 ################################################################################
-# Implementation of the Order and Map types
+# Implementation of the Order and *HealpixMap types
 
 """Abstract type representing the ordering of pixels in a Healpix map.
 See also `RingOrder` and `NestedOrder`.
 """
 abstract type Order end
 
-"""The `RingOrder` type should be used when creating `Map` types in
+"""The `RingOrder` type should be used when creating `HealpixMap` types in
 order to specify that the pixels in the map are sorted in ring
 ordering. (See also `NestedOrder`.)
 """
 abstract type RingOrder <: Order end
 
-"""The `NestedOrder` type should be used when creating `Map` types in
+"""The `NestedOrder` type should be used when creating `HealpixMap` types in
 order to specify that the pixels in the map are sorted in ring
 ordering. (See also `RingOrder`.)
 """
@@ -27,7 +27,7 @@ don't care about the ordering of a map."""
 abstract type AbstractHealpixMap{T} <: AbstractArray{T,1} end
 
 """
-    struct Map{T, O <: Order, AA <: AbstractArray{T, 1}} <: AbstractHealpixMap{T}
+    struct HealpixMap{T, O <: Order, AA <: AbstractArray{T, 1}} <: AbstractHealpixMap{T}
 
 A Healpix map. The type `T` is used for the value of the pixels in a
 map, and it can be anything (even a string!). The type `O` is used to
@@ -35,17 +35,17 @@ specify the ordering of the pixels, and it can either be `RingOrder`
 or `NestedOrder`. The type `AA` is used to store the array of pixels;
 typical types are `Vector`, `CUArray`, `SharedArray`, etc.
 
-A `Map` type contains the following fields:
+A `HealpixMap` type contains the following fields:
 
 - `pixels`: array of pixels
 - `resolution`: instance of a `Resolution` object
 
 You can construct a map using one of the following forms:
 
-- `Map{T, O, AA}(arr)` and `Map{T, O, AA}(nside::Number)` will use
+- `HealpixMap{T, O, AA}(arr)` and `HealpixMap{T, O, AA}(nside::Number)` will use
   `AA` as basetype
 
-- `Map{T, O}(arr)` and `Map{T, O}(nside::Number)` will use `Array{T,
+- `HealpixMap{T, O}(arr)` and `HealpixMap{T, O}(nside::Number)` will use `Array{T,
   1}` as basetype
 
 # Examples
@@ -53,43 +53,43 @@ You can construct a map using one of the following forms:
 The following example creates a map with `NSIDE=32` in `RING` order,
 containing integer values starting from 1:
 
-    mymap = Healpix.Map{Int64, Healpix.RingOrder}(1:Healpix.nside2npix(32))
+    mymap = Healpix.HealpixMap{Int64, Healpix.RingOrder}(1:Healpix.nside2npix(32))
 
 The call to `collect` is required to convert the range in an array.
 
 This example creates a map in `NESTED` order, with `NSIDE=64`, filled
 with zeroes:
 
-    mymap = Healpix.Map{Float64, Healpix.NestedOrder}(64)
+    mymap = Healpix.HealpixMap{Float64, Healpix.NestedOrder}(64)
 
 Finally, the following examples show how to use `SharedArray`:
 
     using SharedArrays
     
     # Create a map with all pixels set to zero
-    mymap = Healpix.Map{Float64, Healpix.NestedOrder, SharedArray{Float64, 1}}(64)
+    mymap = Healpix.HealpixMap{Float64, Healpix.NestedOrder, SharedArray{Float64, 1}}(64)
 
     # Create a map and initialize pixel values with a SharedArray
     pixels = SharedArray{Int64, 1}(1:12 |> collect)
-    mymap = Healpix.Map{Int64, Healpix.RingOrder, SharedArray{Int64, 1}}(m)
+    mymap = Healpix.HealpixMap{Int64, Healpix.RingOrder, SharedArray{Int64, 1}}(m)
 """
-mutable struct Map{T,O<:Order,AA<:AbstractArray{T,1}} <: AbstractHealpixMap{T}
+mutable struct HealpixMap{T,O<:Order,AA<:AbstractArray{T,1}} <: AbstractHealpixMap{T}
     pixels::AA
     resolution::Resolution
 
     """
-        Map{T, O <: Order}(nside) -> Map{T, O}
+        HealpixMap{T, O <: Order}(nside) -> HealpixMap{T, O}
 
     Create an empty map with the specified NSIDE.
     """
-    function Map{T,O,AA}(nside::Number) where {T,O<:Order,AA<:AbstractArray{T,1}}
+    function HealpixMap{T,O,AA}(nside::Number) where {T,O<:Order,AA<:AbstractArray{T,1}}
         new(zeros(T, nside2npix(nside)), Resolution(nside))
     end
 
     """
     Initialize a map from a generic array
     """
-    function Map{T,O,AA}(arr::AA) where {T,O<:Order,AA<:AbstractArray{T,1}}
+    function HealpixMap{T,O,AA}(arr::AA) where {T,O<:Order,AA<:AbstractArray{T,1}}
         nside = npix2nside(length(arr))
         new(arr, Resolution(nside))
     end
@@ -98,47 +98,47 @@ end
 """Convenience function that uses `Array{T, 1}` as the type used to
 hold the vector of pixels.
 """
-function Map{T,O}(nside::Number) where {T,O<:Order}
-    Map{T,O,Array{T,1}}(nside)
+function HealpixMap{T,O}(nside::Number) where {T,O<:Order}
+    HealpixMap{T,O,Array{T,1}}(nside)
 end
 
 """Convenience function that uses `Array{T, 1}` as the type used to
 hold the vector of pixels.
 """
-function Map{T,O}(arr) where {T,O<:Order}
-    Map{T,O,Array{T,1}}(collect(arr))
+function HealpixMap{T,O}(arr) where {T,O<:Order}
+    HealpixMap{T,O,Array{T,1}}(collect(arr))
 end
 
 import Base: +, -, *, /
 
-+(a::Map{T,O,AA}, b::Map{T,O,AA}) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels .+ b.pixels)
--(a::Map{T,O,AA}, b::Map{T,O,AA}) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels .- b.pixels)
-*(a::Map{T,O,AA}, b::Map{T,O,AA}) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels .* b.pixels)
-/(a::Map{T,O,AA}, b::Map{T,O,AA}) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels ./ b.pixels)
++(a::HealpixMap{T,O,AA}, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels .+ b.pixels)
+-(a::HealpixMap{T,O,AA}, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels .- b.pixels)
+*(a::HealpixMap{T,O,AA}, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels .* b.pixels)
+/(a::HealpixMap{T,O,AA}, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels ./ b.pixels)
 
-+(a::Map{T,O,AA}, b::Number) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels .+ b)
--(a::Map{T,O,AA}, b::Number) where {T<:Number,O,AA} = a + (-b)
-*(a::Map{T,O,AA}, b::Number) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels .* b)
-/(a::Map{T,O,AA}, b::Number) where {T<:Number,O,AA} = Map{T,O,AA}(a.pixels ./ b)
++(a::HealpixMap{T,O,AA}, b::Number) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels .+ b)
+-(a::HealpixMap{T,O,AA}, b::Number) where {T<:Number,O,AA} = a + (-b)
+*(a::HealpixMap{T,O,AA}, b::Number) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels .* b)
+/(a::HealpixMap{T,O,AA}, b::Number) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a.pixels ./ b)
 
-+(a::Number, b::Map{T,O,AA}) where {T<:Number,O,AA} = b + a
--(a::Number, b::Map{T,O,AA}) where {T<:Number,O,AA} = b + (-a)
-*(a::Number, b::Map{T,O,AA}) where {T<:Number,O,AA} = b * a
-/(a::Number, b::Map{T,O,AA}) where {T<:Number,O,AA} = Map{T,O,AA}(a ./ b.pixels)
++(a::Number, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = b + a
+-(a::Number, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = b + (-a)
+*(a::Number, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = b * a
+/(a::Number, b::HealpixMap{T,O,AA}) where {T<:Number,O,AA} = HealpixMap{T,O,AA}(a ./ b.pixels)
 
 ################################################################################
 # Iterator interface
 
-Base.size(m::Map{T,O,AA}) where {T,O,AA} = (m.resolution.numOfPixels,)
+Base.size(m::HealpixMap{T,O,AA}) where {T,O,AA} = (m.resolution.numOfPixels,)
 
-Base.IndexStyle(::Type{<:Map{T,O,AA}}) where {T,O,AA} = IndexLinear()
+Base.IndexStyle(::Type{<:HealpixMap{T,O,AA}}) where {T,O,AA} = IndexLinear()
 
-function getindex(m::Map{T,O,AA}, i::Integer) where {T,O,AA}
+function getindex(m::HealpixMap{T,O,AA}, i::Integer) where {T,O,AA}
     1 ≤ i ≤ m.resolution.numOfPixels || throw(BoundsError(m, i))
     m.pixels[i]
 end
 
-function setindex!(m::Map{T,O,AA}, val, i::Integer) where {T,O,AA}
+function setindex!(m::HealpixMap{T,O,AA}, val, i::Integer) where {T,O,AA}
     1 ≤ i ≤ m.resolution.numOfPixels || throw(BoundsError(m, i))
     m.pixels[i] = val
 end

--- a/src/map_io.jl
+++ b/src/map_io.jl
@@ -25,9 +25,9 @@ function readMapFromFITS(f::CFITSIO.FITSFile, column, t::Type{T}) where {T <: Nu
     end
 
     if ringOrdering
-        result = Map{T,RingOrder}(Array{T}(undef, nside2npix(nside)))
+        result = HealpixMap{T,RingOrder}(Array{T}(undef, nside2npix(nside)))
     else
-        result = Map{T,NestedOrder}(Array{T}(undef, nside2npix(nside)))
+        result = HealpixMap{T,NestedOrder}(Array{T}(undef, nside2npix(nside)))
     end
     CFITSIO.fits_read_col(f, column, 1, 1, result.pixels)
 
@@ -65,19 +65,19 @@ function readPolarizedMapFromFITS(
     i, q, u = (readMapFromFITS(f, colidx, t) for colidx in (column_i, column_q, column_u))
     CFITSIO.fits_close_file(f)
 
-    PolarizedMap(i, q, u)
+    PolarizedHealpixMap(i, q, u)
 end
 
 ################################################################################
 
 """
-    savePixelsToFITS(map::Map{T}, f::CFITSIO.FITSFile, column) where {T <: Number}
+    savePixelsToFITS(map::HealpixMap{T}, f::CFITSIO.FITSFile, column) where {T <: Number}
 
 Save the pixels of `map` into the column with index/name `column` in the FITS
 file, which must have been already opened.
 """
 function savePixelsToFITS(
-    map::Map{T},
+    map::HealpixMap{T},
     f::CFITSIO.FITSFile,
     column;
     write_keywords=true,
@@ -101,10 +101,10 @@ function savePixelsToFITS(
 end
 
 """
-    saveToFITS{T <: Number, O <: Order}(map::Map{T, O},
+    saveToFITS{T <: Number, O <: Order}(map::HealpixMap{T, O},
                                         f::CFITSIO.FITSFile,
                                         column)
-    saveToFITS{T <: Number, O <: Order}(map::Map{T, O},
+    saveToFITS{T <: Number, O <: Order}(map::HealpixMap{T, O},
                                         fileName::String,
                                         typechar="D",
                                         unit="",
@@ -114,14 +114,14 @@ Save a Healpix map in the specified (1-based index) column in a FITS
 file. If the code fails, CFITSIO will raise an exception. (Refer to the
 CFITSIO library for more information.)
 """
-function saveToFITS(map::Map{T,RingOrder}, f::CFITSIO.FITSFile, column) where {T <: Number}
+function saveToFITS(map::HealpixMap{T,RingOrder}, f::CFITSIO.FITSFile, column) where {T <: Number}
 
     CFITSIO.fits_update_key(f, "ORDERING", "RING")
     savePixelsToFITS(map, f, column)
 
 end
 
-function saveToFITS(map::Map{T,NestedOrder}, f::CFITSIO.FITSFile, column) where {T <: Number}
+function saveToFITS(map::HealpixMap{T,NestedOrder}, f::CFITSIO.FITSFile, column) where {T <: Number}
 
     CFITSIO.fits_update_key(f, "ORDERING", "NEST")
     savePixelsToFITS(map, f, column)
@@ -129,7 +129,7 @@ function saveToFITS(map::Map{T,NestedOrder}, f::CFITSIO.FITSFile, column) where 
 end
 
 function saveToFITS(
-    map::Map{T,O},
+    map::HealpixMap{T,O},
     fileName::AbstractString;
     typechar="D",
     unit="",
@@ -147,7 +147,7 @@ function saveToFITS(
 end
 
 function saveToFITS(
-    map::PolarizedMap{T,O},
+    map::PolarizedHealpixMap{T,O},
     fileName::AbstractString;
     typechar="D",
     unit="",
@@ -176,8 +176,8 @@ function saveToFITS(
 end
 
 @doc raw"""
-    saveToFITS(map::Map{T, O}, filename::AbstractString, typechar="D", unit="", extname="MAP") where {T <: Number, O <: Order}
-    saveToFITS(map::PolarizedMap{T, O}, filename::AbstractString, typechar="D", unit="", extname="MAP") where {T <: Number, O <: Order}
+    saveToFITS(map::HealpixMap{T, O}, filename::AbstractString, typechar="D", unit="", extname="MAP") where {T <: Number, O <: Order}
+    saveToFITS(map::PolarizedHealpixMap{T, O}, filename::AbstractString, typechar="D", unit="", extname="MAP") where {T <: Number, O <: Order}
 
 Save a map into a FITS file. The name of the file is specified in
 `filename`; if it begins with `!`, existing files will be overwritten

--- a/src/map_pixelfunc.jl
+++ b/src/map_pixelfunc.jl
@@ -1,17 +1,17 @@
 ################################################################################
 
-ang2pix(map::Map{T,RingOrder,AA}, theta, phi) where {T,AA} =
+ang2pix(map::HealpixMap{T,RingOrder,AA}, theta, phi) where {T,AA} =
     ang2pixRing(map.resolution, theta, phi)
-ang2pix(map::Map{T,NestedOrder,AA}, theta, phi) where {T,AA} =
+ang2pix(map::HealpixMap{T,NestedOrder,AA}, theta, phi) where {T,AA} =
     ang2pixNest(map.resolution, theta, phi)
-ang2pix(map::PolarizedMap{T,RingOrder,AA}, theta, phi) where {T,AA} =
+ang2pix(map::PolarizedHealpixMap{T,RingOrder,AA}, theta, phi) where {T,AA} =
     ang2pixRing(map.i.resolution, theta, phi)
-ang2pix(map::PolarizedMap{T,NestedOrder,AA}, theta, phi) where {T,AA} =
+ang2pix(map::PolarizedHealpixMap{T,NestedOrder,AA}, theta, phi) where {T,AA} =
     ang2pixNest(map.i.resolution, theta, phi)
 
 @doc raw"""
-    ang2pix{T, O, AA}(map::Map{T, O}, theta, phi)
-    ang2pix{T, O, AA}(map::PolarizedMap{T, O}, theta, phi)
+    ang2pix{T, O, AA}(map::HealpixMap{T, O}, theta, phi)
+    ang2pix{T, O, AA}(map::PolarizedHealpixMap{T, O}, theta, phi)
 
 Convert the direction specified by the colatitude `theta` (∈ [0, π])
 and the longitude `phi` (∈ [0, 2π]) into the index of the pixel in the
@@ -21,16 +21,16 @@ ang2pix
 
 ################################################################################
 
-pix2ang(map::Map{T,RingOrder,AA}, ipix) where {T,AA} = pix2angRing(map.resolution, ipix)
-pix2ang(map::Map{T,NestedOrder,AA}, ipix) where {T,AA} = pix2angNest(map.resolution, ipix)
-pix2ang(map::PolarizedMap{T,RingOrder,AA}, ipix) where {T,AA} =
+pix2ang(map::HealpixMap{T,RingOrder,AA}, ipix) where {T,AA} = pix2angRing(map.resolution, ipix)
+pix2ang(map::HealpixMap{T,NestedOrder,AA}, ipix) where {T,AA} = pix2angNest(map.resolution, ipix)
+pix2ang(map::PolarizedHealpixMap{T,RingOrder,AA}, ipix) where {T,AA} =
     pix2angRing(map.i.resolution, ipix)
-pix2ang(map::PolarizedMap{T,NestedOrder,AA}, ipix) where {T,AA} =
+pix2ang(map::PolarizedHealpixMap{T,NestedOrder,AA}, ipix) where {T,AA} =
     pix2angNest(map.i.resolution, ipix)
 
 @doc raw"""
-    pix2ang{T, O <: Order}(map::Map{T, O}, ipix) -> (Float64, Float64)
-    pix2ang{T, O <: Order}(map::PolarizedMap{T, O}, ipix) -> (Float64, Float64)
+    pix2ang{T, O <: Order}(map::HealpixMap{T, O}, ipix) -> (Float64, Float64)
+    pix2ang{T, O <: Order}(map::PolarizedHealpixMap{T, O}, ipix) -> (Float64, Float64)
 
 Return the pair (`theta`, `phi`), where `theta` is the colatitude and
 `phi` the longitude of the direction of the pixel center with index
@@ -41,7 +41,7 @@ pix2ang
 ################################################################################
 # Interpolation
 
-function interpolate(m::Map{T,RingOrder,AA}, θ, ϕ, pixbuf, weightbuf) where {T,AA}
+function interpolate(m::HealpixMap{T,RingOrder,AA}, θ, ϕ, pixbuf, weightbuf) where {T,AA}
     getinterpolRing(m.resolution, θ, ϕ, pixbuf, weightbuf)
 
     result = zero(weightbuf[1])
@@ -52,7 +52,7 @@ function interpolate(m::Map{T,RingOrder,AA}, θ, ϕ, pixbuf, weightbuf) where {T
     result
 end
 
-function interpolate(m::Map{T,RingOrder,AA}, θ, ϕ) where {T,AA}
+function interpolate(m::HealpixMap{T,RingOrder,AA}, θ, ϕ) where {T,AA}
     pixbuf = Array{Int}(undef, 4)
     weightbuf = Array{Float64}(undef, 4)
 
@@ -60,8 +60,8 @@ function interpolate(m::Map{T,RingOrder,AA}, θ, ϕ) where {T,AA}
 end
 
 """
-    interpolate(m::Map{T, RingOrder, AA}, θ, ϕ) -> Value
-    interpolate(m::Map{T, RingOrder, AA}, θ, ϕ, pixbuf, weightbuf) -> Value
+    interpolate(m::HealpixMap{T, RingOrder, AA}, θ, ϕ) -> Value
+    interpolate(m::HealpixMap{T, RingOrder, AA}, θ, ϕ, pixbuf, weightbuf) -> Value
 
 Return an interpolated value of the map along the specified direction.
 
@@ -74,7 +74,7 @@ respectively. They can be reused across multiple calls of
 pixbuf = Array{Int}(undef, 4)
 weightbuf = Array{Float64}(undef, 4)
 
-m = Map{Float64, RingOrder}(1)
+m = HealpixMap{Float64, RingOrder}(1)
 for (θ, ϕ) in [(0., 0.), (π/2, π/2)]
     println(interpolate!(m, θ, ϕ, pixbuf, weightbuf))
 end
@@ -84,64 +84,64 @@ interpolate
 
 
 @doc raw"""
-    nest2ring(m_nest::Map{T, NestedOrder, AA}) where {T, AA}
+    nest2ring(m_nest::HealpixMap{T, NestedOrder, AA}) where {T, AA}
 
 Convert a map from nested to ring order. This version allocates a new array of the same
 array type as the input.
 
 # Arguments:
-- `m_nest::Map{T, NestedOrder, AA}`: map of type `NestedOrder`
+- `m_nest::HealpixMap{T, NestedOrder, AA}`: map of type `NestedOrder`
 
 # Returns: 
-- `Map{T, RingOrder, AA}`: the input map converted to `RingOrder`
+- `HealpixMap{T, RingOrder, AA}`: the input map converted to `RingOrder`
 
 # Examples
 ```julia-repl
-julia> m_nest = Map{Float64,NestedOrder}(rand(nside2npix(64)));
+julia> m_nest = HealpixMap{Float64,NestedOrder}(rand(nside2npix(64)));
 
 julia> nest2ring(m_nest)
-49152-element Map{Float64, RingOrder, Vector{Float64}}:
+49152-element HealpixMap{Float64, RingOrder, Vector{Float64}}:
  0.4703834205807309
  ⋮
  0.3945848051663148
 ```
 """
-function nest2ring(m_nest::Map{T, NestedOrder, AA}) where {T, AA}
-    m_ring = Map{T, RingOrder, AA}(AA(undef, size(m_nest.pixels)))
+function nest2ring(m_nest::HealpixMap{T, NestedOrder, AA}) where {T, AA}
+    m_ring = HealpixMap{T, RingOrder, AA}(AA(undef, size(m_nest.pixels)))
     nest2ring!(m_ring, m_nest)
     return m_ring
 end
 
 
 @doc raw"""
-    nest2ring!(m_ring_dst::Map{T, RingOrder, AAR}, 
-               m_nest_src::Map{T, NestedOrder, AAN}) where {T, AAN, AAR}
+    nest2ring!(m_ring_dst::HealpixMap{T, RingOrder, AAR}, 
+               m_nest_src::HealpixMap{T, NestedOrder, AAN}) where {T, AAN, AAR}
 
 Convert a map from nested to ring order. This version takes a nested map in the 
 second argument and writes it to the nested map provided in the first argument,
 following the standard Julia `func!(dst, src)` convention.
 
 # Arguments:
-- `m_ring_dst::Map{T, NestedOrder, AA}`: map of type `NestedOrder`
-- `m_nest_src::Map{T, NestedOrder, AAN}`: map of type `RingOrder`
+- `m_ring_dst::HealpixMap{T, NestedOrder, AA}`: map of type `NestedOrder`
+- `m_nest_src::HealpixMap{T, NestedOrder, AAN}`: map of type `RingOrder`
 
 # Returns: 
-- `Map{T, RingOrder, AA}`: the input map converted to `RingOrder`
+- `HealpixMap{T, RingOrder, AA}`: the input map converted to `RingOrder`
 
 # Examples
 ```julia-repl
-julia> m_nest = Map{Float64,NestedOrder}(rand(nside2npix(64)));
+julia> m_nest = HealpixMap{Float64,NestedOrder}(rand(nside2npix(64)));
 
-julia> m_ring = Map{Float64,RingOrder}(64);
+julia> m_ring = HealpixMap{Float64,RingOrder}(64);
 
 julia> nest2ring!(m_ring, m_nest)
-49152-element Map{Float64, RingOrder, Vector{Float64}}:
+49152-element HealpixMap{Float64, RingOrder, Vector{Float64}}:
  0.33681791815569895
  ⋮
  0.9092457003948482
 ```
 """
-function nest2ring!(m_ring_dst::Map{T, RingOrder, AAR}, m_nest_src::Map{T, NestedOrder, AAN}) where {T, AAN, AAR}
+function nest2ring!(m_ring_dst::HealpixMap{T, RingOrder, AAR}, m_nest_src::HealpixMap{T, NestedOrder, AAN}) where {T, AAN, AAR}
     res_nest = m_nest_src.resolution
     for i_nest in eachindex(m_nest_src.pixels)
         i_ring = nest2ring(res_nest, i_nest)
@@ -152,64 +152,64 @@ end
 
 
 @doc raw"""
-    ring2nest(m_ring::Map{T, RingOrder, AA}) where {T, AA}
+    ring2nest(m_ring::HealpixMap{T, RingOrder, AA}) where {T, AA}
 
 Convert a map from ring to nested order. This version allocates a new array of the same
 array type as the input.
 
 # Arguments:
-- `m_ring::Map{T, RingOrder, AA}`: map of type `RingOrder`
+- `m_ring::HealpixMap{T, RingOrder, AA}`: map of type `RingOrder`
 
 # Returns: 
-- `Map{T, NestedOrder, AA}`: the input map converted to `NestedOrder`
+- `HealpixMap{T, NestedOrder, AA}`: the input map converted to `NestedOrder`
 
 # Examples
 ```julia-repl
-julia> m_ring = Map{Float64,RingOrder}(rand(nside2npix(64)));
+julia> m_ring = HealpixMap{Float64,RingOrder}(rand(nside2npix(64)));
 
 julia> ring2nest(m_ring)
-49152-element Map{Float64, NestedOrder, Vector{Float64}}:
+49152-element HealpixMap{Float64, NestedOrder, Vector{Float64}}:
  0.0673134062168923
  ⋮
  0.703460503535335
 ```
 """
-function ring2nest(m_ring::Map{T, RingOrder, AA}) where {T, AA}
-    m_nest = Map{T, NestedOrder, AA}(AA(undef, size(m_ring.pixels)))
+function ring2nest(m_ring::HealpixMap{T, RingOrder, AA}) where {T, AA}
+    m_nest = HealpixMap{T, NestedOrder, AA}(AA(undef, size(m_ring.pixels)))
     ring2nest!(m_nest, m_ring)
     return m_nest
 end
 
 
 @doc raw"""
-    ring2nest!(m_nest_dst::Map{T, NestedOrder, AAN}, 
-               m_ring_src::Map{T, RingOrder, AAR}) where {T, AAR, AAN}
+    ring2nest!(m_nest_dst::HealpixMap{T, NestedOrder, AAN}, 
+               m_ring_src::HealpixMap{T, RingOrder, AAR}) where {T, AAR, AAN}
 
 Convert a map from ring to nested order. This version takes a nested map in the 
 second argument and writes it to the nested map provided in the first argument,
 following the standard Julia `func!(dst, src)` convention.
 
 # Arguments:
-- `m_nest_dst::Map{T, NestedOrder, AAN}`: map of type `RingOrder`
-- `m_ring_src::Map{T, RingOrder, AA}`: map of type `RingOrder`
+- `m_nest_dst::HealpixMap{T, NestedOrder, AAN}`: map of type `RingOrder`
+- `m_ring_src::HealpixMap{T, RingOrder, AA}`: map of type `RingOrder`
 
 # Returns: 
-- `Map{T, NestedOrder, AA}`: the input map converted to `NestedOrder`
+- `HealpixMap{T, NestedOrder, AA}`: the input map converted to `NestedOrder`
 
 # Examples
 ```julia-repl
-julia> m_ring = Map{Float64,RingOrder}(rand(nside2npix(64)));
+julia> m_ring = HealpixMap{Float64,RingOrder}(rand(nside2npix(64)));
 
-julia> m_nest = Map{Float64,RingOrder}(64);
+julia> m_nest = HealpixMap{Float64,RingOrder}(64);
 
 julia> ring2nest!(m_nest, m_ring)
-49152-element Map{Float64, NestedOrder, Vector{Float64}}:
+49152-element HealpixMap{Float64, NestedOrder, Vector{Float64}}:
  0.0673134062168923
  ⋮
  0.703460503535335
 ```
 """
-function ring2nest!(m_nest_dst::Map{T, NestedOrder, AAN}, m_ring_src::Map{T, RingOrder, AAR}) where {T, AAR, AAN}
+function ring2nest!(m_nest_dst::HealpixMap{T, NestedOrder, AAN}, m_ring_src::HealpixMap{T, RingOrder, AAR}) where {T, AAR, AAN}
     res_ring = m_ring_src.resolution
     for i_ring in eachindex(m_ring_src.pixels)
         i_nest = ring2nest(res_ring, i_ring)
@@ -220,14 +220,14 @@ end
 
 
 """
-    udgrade(input_map::Map{T,O,AA}, output_nside; kw...) where {T,O,AA} -> Map{T,O,AA}
+    udgrade(input_map::HealpixMap{T,O,AA}, output_nside; kw...) where {T,O,AA} -> HealpixMap{T,O,AA}
 
 Upgrades or downgrades a map to a target nside. Always makes a copy. This is very fast 
 for nested orderings, but slow for ring because one needs to transform to nested ordering 
 first.
 
 # Arguments:
-- `input_map::Map{T,O,AA}`: the map to upgrade/downgrade
+- `input_map::HealpixMap{T,O,AA}`: the map to upgrade/downgrade
 - `output_nside`: desired nside
 
 # Keywords:
@@ -236,28 +236,28 @@ first.
     if true, the entire downgraded pixel is set to UNSEEN.
 
 # Returns: 
-- `Map{T,O,AA}`: upgraded/downgraded map in the same ordering as the input
+- `HealpixMap{T,O,AA}`: upgraded/downgraded map in the same ordering as the input
 
 # Examples
 ```julia-repl
-julia> A = Map{Float64, NestedOrder}(ones(nside2npix(4)))
-192-element Map{Float64, RingOrder, Vector{Float64}}:
+julia> A = HealpixMap{Float64, NestedOrder}(ones(nside2npix(4)))
+192-element HealpixMap{Float64, RingOrder, Vector{Float64}}:
  1.0
  ⋮
  1.0
 
 julia> Healpix.udgrade(A, 2)
-48-element Map{Float64, NestedOrder, Vector{Float64}}:
+48-element HealpixMap{Float64, NestedOrder, Vector{Float64}}:
  1.0
  ⋮
  1.0
 ```
 """
-function udgrade(map_in::Map{T,O,AA}, nside_out; 
+function udgrade(map_in::HealpixMap{T,O,AA}, nside_out; 
                  threshold=abs(1e-6UNSEEN), pess=false) where {T,O<:NestedOrder,AA}
     nside_in = map_in.resolution.nside
     npix_out = nside2npix(nside_out)
-    map_out = Map{T,O,AA}(nside_out)
+    map_out = HealpixMap{T,O,AA}(nside_out)
 
     if nside_in == nside_out
         map_out.pixels .= map_in.pixels
@@ -295,7 +295,7 @@ function udgrade(map_in::Map{T,O,AA}, nside_out;
     return map_out
 end
 # just convert to nest and udgrade if we get a ring
-function udgrade(map_in::Map{T,O,AA}, nside_out; 
+function udgrade(map_in::HealpixMap{T,O,AA}, nside_out; 
                  threshold=abs(1e-6UNSEEN), pess=true) where {T,O<:RingOrder,AA}
     map_nest = ring2nest(map_in)
     map_out = udgrade(map_nest, nside_out; threshold=threshold, pess=pess)

--- a/src/mapmaking.jl
+++ b/src/mapmaking.jl
@@ -9,8 +9,8 @@ itself and the hit map.
 function tod2map(pixidx, tod::Array{T}; nside = 128, ordering = Healpix.RingOrder) where {T}
     @assert length(pixidx) == length(tod)
 
-    binnedmap = Map{T,ordering}(nside)
-    hitmap = Map{Int,ordering}(nside)
+    binnedmap = HealpixMap{T,ordering}(nside)
+    hitmap = HealpixMap{Int,ordering}(nside)
 
     @inbounds for i in eachindex(pixidx)
         if !ismissing(tod[i])
@@ -29,7 +29,7 @@ function tod2map(pixidx, tod::Array{T}; nside = 128, ordering = Healpix.RingOrde
 end
 
 @doc raw"""
-    combinemaps{T, O, H}(destmap::Map{T, O}, desthitmap::Map{H, O}, othermap::Map{T, O}, otherhitmap::Map{H, O})
+    combinemaps{T, O, H}(destmap::HealpixMap{T, O}, desthitmap::HealpixMap{H, O}, othermap::HealpixMap{T, O}, otherhitmap::HealpixMap{H, O})
 
 Sum "othermap" to "destmap", assuming that both maps have been
 produced by binning TODs. The parameters `desthitmap` and
@@ -37,10 +37,10 @@ produced by binning TODs. The parameters `desthitmap` and
 and `desthitmap` are updated.
 """
 function combinemaps!(
-    destmap::Map{T,O},
-    desthitmap::Map{H,O},
-    othermap::Map{T,O},
-    otherhitmap::Map{H,O},
+    destmap::HealpixMap{T,O},
+    desthitmap::HealpixMap{H,O},
+    othermap::HealpixMap{T,O},
+    otherhitmap::HealpixMap{H,O},
 ) where {T,O,H}
     (
         conformables(destmap, othermap) &&

--- a/src/polarizedmap.jl
+++ b/src/polarizedmap.jl
@@ -1,17 +1,17 @@
 ################################################################################
-# Implementation of the PolarizedMap type
+# Implementation of the PolarizedHealpixMap type
 
 """
-    GenericPolarizedMap{T}
+    GenericPolarizedHealpixMap{T}
 
 An abstract type representing an Healpix polarized map without a
 specified ordering. This can be used to implement multiple dispatch
 when you don't care about the ordering of a map.
 """
-abstract type GenericPolarizedMap{T} end
+abstract type GenericPolarizedHealpixMap{T} end
 
 @doc raw"""
-    mutable struct PolarizedMap{T, O <: Healpix.Order, AA <: AbstractArray{T, 1}}
+    mutable struct PolarizedHealpixMap{T, O <: Healpix.Order, AA <: AbstractArray{T, 1}}
 
 A polarized I/Q/U map. It contains three Healpix maps with the same NSIDE:
 
@@ -20,22 +20,22 @@ A polarized I/Q/U map. It contains three Healpix maps with the same NSIDE:
 - `u`
 
 You can create an instance of this type using the function
-[`PolarizedMap{T,O}`](@ref), which comes in three flavours:
+[`PolarizedHealpixMap{T,O}`](@ref), which comes in three flavours:
 
-- `PolarizedMap(i::Map{T,O,AA}, q::Map{T,O,AA}, u::Map{T,O,AA})`
-- `PolarizedMap{T,O}(i::AbstractVector{T}, q::AbstractVector{T}, u::AbstractVector{T})`
-- `PolarizedMap{T,O}(nside::Number)`
+- `PolarizedHealpixMap(i::HealpixMap{T,O,AA}, q::HealpixMap{T,O,AA}, u::HealpixMap{T,O,AA})`
+- `PolarizedHealpixMap{T,O}(i::AbstractVector{T}, q::AbstractVector{T}, u::AbstractVector{T})`
+- `PolarizedHealpixMap{T,O}(nside::Number)`
 
 """
-mutable struct PolarizedMap{T,O<:Order,AA<:AbstractArray{T,1}} <: GenericPolarizedMap{T}
-    i::Map{T,O,AA}
-    q::Map{T,O,AA}
-    u::Map{T,O,AA}
+mutable struct PolarizedHealpixMap{T,O<:Order,AA<:AbstractArray{T,1}} <: GenericPolarizedHealpixMap{T}
+    i::HealpixMap{T,O,AA}
+    q::HealpixMap{T,O,AA}
+    u::HealpixMap{T,O,AA}
 
-    function PolarizedMap{T,O,AA}(
-        i::Map{T,O,AA},
-        q::Map{T,O,AA},
-        u::Map{T,O,AA},
+    function PolarizedHealpixMap{T,O,AA}(
+        i::HealpixMap{T,O,AA},
+        q::HealpixMap{T,O,AA},
+        u::HealpixMap{T,O,AA},
     ) where {T,O<:Order,AA<:AbstractArray{T,1}}
         ((length(i) != length(q)) || (length(i) != length(q))) &&
             throw(ArgumentError("The three I/Q/U maps must have the same resolution"),)
@@ -43,7 +43,7 @@ mutable struct PolarizedMap{T,O<:Order,AA<:AbstractArray{T,1}} <: GenericPolariz
         new(i, q, u)
     end
 
-    function PolarizedMap{T,O,AA}(
+    function PolarizedHealpixMap{T,O,AA}(
         i::AA,
         q::AA,
         u::AA,
@@ -51,26 +51,26 @@ mutable struct PolarizedMap{T,O<:Order,AA<:AbstractArray{T,1}} <: GenericPolariz
         ((length(i) != length(q)) || (length(i) != length(q))) &&
             throw(ArgumentError("The three I/Q/U vectors must have the same resolution"),)
 
-        new(Map{T,O,AA}(i), Map{T,O,AA}(q), Map{T,O,AA}(u))
+        new(HealpixMap{T,O,AA}(i), HealpixMap{T,O,AA}(q), HealpixMap{T,O,AA}(u))
     end
 
-    function PolarizedMap{T,O,AA}(nside::Number) where {T,O<:Order,AA<:AbstractArray{T,1}}
-        new(Map{T,O,AA}(nside), Map{T,O,AA}(nside), Map{T,O,AA}(nside))
+    function PolarizedHealpixMap{T,O,AA}(nside::Number) where {T,O<:Order,AA<:AbstractArray{T,1}}
+        new(HealpixMap{T,O,AA}(nside), HealpixMap{T,O,AA}(nside), HealpixMap{T,O,AA}(nside))
     end
 end
 
-function PolarizedMap{T,O}(nside::Number) where {T,O<:Order}
-    PolarizedMap{T,O,Array{T,1}}(nside)
+function PolarizedHealpixMap{T,O}(nside::Number) where {T,O<:Order}
+    PolarizedHealpixMap{T,O,Array{T,1}}(nside)
 end
 
-function PolarizedMap{T,O}(i::Array{T,1}, q::Array{T,1}, u::Array{T,1}) where {T,O<:Order}
-    PolarizedMap{T,O,Array{T,1}}(i, q, u)
+function PolarizedHealpixMap{T,O}(i::Array{T,1}, q::Array{T,1}, u::Array{T,1}) where {T,O<:Order}
+    PolarizedHealpixMap{T,O,Array{T,1}}(i, q, u)
 end
 
-function PolarizedMap(
-    i::Map{T,O,AA},
-    q::Map{T,O,AA},
-    u::Map{T,O,AA},
+function PolarizedHealpixMap(
+    i::HealpixMap{T,O,AA},
+    q::HealpixMap{T,O,AA},
+    u::HealpixMap{T,O,AA},
 ) where {T,O<:Order,AA<:AbstractArray{T,1}}
-    return PolarizedMap{T,O,AA}(i, q, u)
+    return PolarizedHealpixMap{T,O,AA}(i, q, u)
 end

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -17,7 +17,7 @@ import RecipesBase
 
 
 """
-    project(invprojfn, m::Map{T, O, AA}, bmpwidth, bmpheight; kwargs...)
+    project(invprojfn, m::HealpixMap{T, O, AA}, bmpwidth, bmpheight; kwargs...)
 
 Return a 2D bitmap (array) containing a cartographic projection of the
 map and a 2D bitmap containing a boolean mask. The size of the bitmap
@@ -39,7 +39,7 @@ and unseen pixels are marked as `missing`.
 """
 function project(
     invprojfn,
-    m::Map{T,O,AA},
+    m::HealpixMap{T,O,AA},
     bmpwidth,
     bmpheight,
     projparams = Dict(),
@@ -279,18 +279,18 @@ end
 ################################################################################
 
 """
-    equirectangular(m::Map{T,O,AA}; kwargs...) where {T <: Number, O, AA}
+    equirectangular(m::HealpixMap{T,O,AA}; kwargs...) where {T <: Number, O, AA}
 
 High-level wrapper around `project` for equirectangular projections.
 """
-function equirectangular(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
+function equirectangular(m::HealpixMap{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
     width = get(projparams, :width, 720)
     height = get(projparams, :height, width)
     project(equiprojinv, m, width, height, projparams)
 end
 
 """
-    mollweide(m::Map{T, O, AA}, projparams = Dict()) where {T <: Number, O, AA}
+    mollweide(m::HealpixMap{T, O, AA}, projparams = Dict()) where {T <: Number, O, AA}
 
 High-level wrapper around `project` for Mollweide projections.
 
@@ -300,14 +300,14 @@ The following parameters can be set in the `projparams` dictionary:
 - `height`: height of the image, in pixels; if not specified, it will be assumed
   to be equal to `width`
 """
-function mollweide(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
+function mollweide(m::HealpixMap{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
     width = get(projparams, :width, 720)
     height = get(projparams, :height, width ÷ 2)
     project(mollweideprojinv, m, width, height, projparams)
 end
 
 """
-    orthographic(m::Map{T,O}, projparams = Dict()) where {T <: Number,O <: Order}
+    orthographic(m::HealpixMap{T,O}, projparams = Dict()) where {T <: Number,O <: Order}
 
 High-level wrapper around `project` for orthographic projections.
 
@@ -319,7 +319,7 @@ The following parameters can be set in the `projparams` dictionary:
 - `center`: position of the pixel in the middle of the left globe (*latitude* and
   longitude).
 """
-function orthographic(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
+function orthographic(m::HealpixMap{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
     width = get(projparams, :width, 720)
     height = get(projparams, :height, width)
     ϕ0, λ0 = get(projparams, :center, (0, 0))
@@ -329,7 +329,7 @@ function orthographic(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA
 end
 
 """
-    orthographic2(m::Map{T, O, AA}, projparams = Dict()) where {T <: Number, O, AA}
+    orthographic2(m::HealpixMap{T, O, AA}, projparams = Dict()) where {T <: Number, O, AA}
 
 High-level wrapper around `project` for stereo orthographic projections.
 
@@ -341,7 +341,7 @@ The following parameters can be set in the `projparams` dictionary:
 - `center`: position of the pixel in the middle of the left globe (*latitude* and
   longitude). Default is (0, 0).
 """
-function orthographic2(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
+function orthographic2(m::HealpixMap{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
     width = get(projparams, :width, 720)
     height = get(projparams, :height, width ÷ 2)
     ϕ0, λ0 = get(projparams, :center, (0, 0))
@@ -351,7 +351,7 @@ function orthographic2(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,A
 end
 
 """
-    gnomonic(m::Map{T, O, AA}, projparams = Dict()) where {T <: Number, O, AA}
+    gnomonic(m::HealpixMap{T, O, AA}, projparams = Dict()) where {T <: Number, O, AA}
 
 High-level wrapper around `project` for gnomonic projections.
 
@@ -375,7 +375,7 @@ The following parameters can be set in the `projparams` dictionary:
 plot(m, gnomonic, Dict(:fov_rad = deg2rad(1.5), :center = (0, 0, deg2rad(45))))
 ````
 """
-function gnomonic(m::Map{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
+function gnomonic(m::HealpixMap{T,O,AA}, projparams = Dict()) where {T<:Number,O,AA}
     width = get(projparams, :width, 720)
     height = get(projparams, :height, width)
     ϕ0, λ0, ψ0 = get(projparams, :center, (0, 0, 0))
@@ -388,7 +388,7 @@ end
 ################################################################################
 
 RecipesBase.@recipe function plot(
-    m::Map{T,O,AA},
+    m::HealpixMap{T,O,AA},
     projection = mollweide,
     projparams = Dict(),
 ) where {T<:Number,O,AA}
@@ -441,7 +441,7 @@ RecipesBase.@recipe function plot(
 end
 
 @doc raw"""
-    plot(m::Map{T, O, AA}, projection = mollweide, projparams = Dict())
+    plot(m::HealpixMap{T, O, AA}, projection = mollweide, projparams = Dict())
 
 Draw a representation of the map, using some specific projection. The
 parameter `projection` must be a function returning the

--- a/src/sphtfunc.jl
+++ b/src/sphtfunc.jl
@@ -72,8 +72,8 @@ end
 
 
 """
-    map2alm!(map::Map{Float64, RingOrder, Array{Float64, 1}}, alm::Alm{ComplexF64, Array{ComplexF64, 1}}; niter::Integer=3)
-    map2alm!(map::PolarizedMap{Float64, RingOrder, Array{Float64, 1}}, alm::Array{Alm{ComplexF64, Array{ComplexF64, 1}},1};
+    map2alm!(map::HealpixMap{Float64, RingOrder, Array{Float64, 1}}, alm::Alm{ComplexF64, Array{ComplexF64, 1}}; niter::Integer=3)
+    map2alm!(map::PolarizedHealpixMap{Float64, RingOrder, Array{Float64, 1}}, alm::Array{Alm{ComplexF64, Array{ComplexF64, 1}},1};
         niter::Integer=3)
 
 This function performs a spherical harmonic transform on the map and places the results
@@ -83,8 +83,8 @@ done in-place.
 # Arguments
 
 - `map`: the map that must be decomposed in spherical harmonics. It
-  can either be a `Map{Float64, RingOrder}` type (scalar map) or a
-  `PolarizedMap{Float64, RingOrder}` type (polarized map).
+  can either be a `HealpixMap{Float64, RingOrder}` type (scalar map) or a
+  `PolarizedHealpixMap{Float64, RingOrder}` type (polarized map).
 
 - `alm::Alm{ComplexF64, Array{ComplexF64, 1}}`: the spherical harmonic
   coefficients to be written to.
@@ -97,7 +97,7 @@ done in-place.
 map2alm!
 
 function map2alm!(
-    map::Map{Float64,RingOrder,Array{Float64,1}},
+    map::HealpixMap{Float64,RingOrder,Array{Float64,1}},
     alm::Alm{ComplexF64,Array{ComplexF64,1}};
     niter::Integer=3,
 )
@@ -118,7 +118,7 @@ function map2alm!(
 end
 
 function map2alm!(
-    map::PolarizedMap{Float64,RingOrder,Array{Float64,1}},
+    map::PolarizedHealpixMap{Float64,RingOrder,Array{Float64,1}},
     alm::Array{Alm{ComplexF64,Array{ComplexF64,1}},1};
     niter::Integer=3,
 )
@@ -156,9 +156,9 @@ end
 
 
 """
-    map2alm(map::Map{Float64, RingOrder, AA};
+    map2alm(map::HealpixMap{Float64, RingOrder, AA};
         lmax=nothing, mmax=nothing, niter::Integer=3)
-    map2alm(m::Map{T, RingOrder, AA}; lmax=nothing, mmax=nothing,
+    map2alm(m::HealpixMap{T, RingOrder, AA}; lmax=nothing, mmax=nothing,
         niter::Integer=3) where {T <: Real, AA <: AbstractArray{T, 1} }
 
 Compute the spherical harmonic coefficients of a map. To enhance
@@ -170,7 +170,7 @@ converted to types based on Float64.
 # Arguments
 
 - `map`: the map to decompose in spherical harmonics. It can either be
-  a `Map{T, RingOrder, AA}` type (scalar map) or a `PolarizedMap{T,
+  a `HealpixMap{T, RingOrder, AA}` type (scalar map) or a `PolarizedHealpixMap{T,
   RingOrder, AA}` type (polarized map).
 
 # Keywords
@@ -191,7 +191,7 @@ converted to types based on Float64.
 map2alm
 
 function map2alm(
-    map::Map{Float64,RingOrder,Array{Float64,1}};
+    map::HealpixMap{Float64,RingOrder,Array{Float64,1}};
     lmax=nothing,
     mmax=nothing,
     niter::Integer=3,
@@ -208,7 +208,7 @@ function map2alm(
 end
 
 function map2alm(
-    map::PolarizedMap{Float64,RingOrder,Array{Float64,1}};
+    map::PolarizedHealpixMap{Float64,RingOrder,Array{Float64,1}};
     lmax=nothing,
     mmax=nothing,
     niter::Integer=3,
@@ -230,18 +230,18 @@ end
 
 # convert maps to Float64
 function map2alm(
-    map::Map{T,RingOrder,AA};
+    map::HealpixMap{T,RingOrder,AA};
     lmax=nothing,
     mmax=nothing,
     niter::Integer=3,
 ) where {T <: Real,AA <: AbstractArray{T,1}}
-    map_float = Map{Float64,RingOrder}(convert(Array{Float64,1}, map.pixels))
+    map_float = HealpixMap{Float64,RingOrder}(convert(Array{Float64,1}, map.pixels))
     return map2alm(map_float, lmax=lmax, mmax=mmax, niter=niter)
 end
 
-# convert PolarizedMap to Float64
+# convert PolarizedHealpixMap to Float64
 function map2alm(
-    map::PolarizedMap{T,RingOrder,AA};
+    map::PolarizedHealpixMap{T,RingOrder,AA};
     lmax=nothing,
     mmax=nothing,
     niter::Integer=3,
@@ -249,14 +249,14 @@ function map2alm(
     m_i = convert(Array{Float64,1}, map.i)
     m_q = convert(Array{Float64,1}, map.q)
     m_u = convert(Array{Float64,1}, map.u)
-    pol_map_float = PolarizedMap{Float64,RingOrder}(m_i, m_q, m_u)
+    pol_map_float = PolarizedHealpixMap{Float64,RingOrder}(m_i, m_q, m_u)
     return map2alm(pol_map_float, lmax=lmax, mmax=mmax, niter=niter)
 end
 
 
 """
-    alm2map!(alm::Alm{ComplexF64, Array{ComplexF64, 1}}, map::Map{Float64, RingOrder, Array{Float64, 1}})
-    alm2map!(alm::Array{Alm{ComplexF64, Array{ComplexF64, 1}},1}, map::PolarizedMap{Float64, RingOrder, Array{Float64, 1}})
+    alm2map!(alm::Alm{ComplexF64, Array{ComplexF64, 1}}, map::HealpixMap{Float64, RingOrder, Array{Float64, 1}})
+    alm2map!(alm::Array{Alm{ComplexF64, Array{ComplexF64, 1}},1}, map::PolarizedHealpixMap{Float64, RingOrder, Array{Float64, 1}})
 
 This function performs a spherical harmonic transform on the map and
 places the results in the passed `alm` object. This function requires
@@ -268,8 +268,8 @@ types derived from Float64, since it is done in-place.
   coefficients to perform the spherical harmonic transform on.
 
 - `map`: the map that will contain the result. It can either be a
-  `Map{Float64, RingOrder, Array{Float64, 1}}` type (scalar map) or a
-  `PolarizedMap{Float64, RingOrder, Array{Float64, 1}}` (polarized
+  `HealpixMap{Float64, RingOrder, Array{Float64, 1}}` type (scalar map) or a
+  `PolarizedHealpixMap{Float64, RingOrder, Array{Float64, 1}}` (polarized
   map).
 
 """
@@ -278,7 +278,7 @@ alm2map!
 # in-place alm2map for spin-0
 function alm2map!(
     alm::Alm{ComplexF64,Array{ComplexF64,1}},
-    map::Map{Float64,RingOrder,Array{Float64,1}},
+    map::HealpixMap{Float64,RingOrder,Array{Float64,1}},
 )
     geom_info = Libsharp.make_healpix_geom_info(map.resolution.nside, 1)
     alm_info = Libsharp.make_triangular_alm_info(alm.lmax, alm.mmax, 1)
@@ -296,7 +296,7 @@ end
 # in-place alm2map for TEB to IQU
 function alm2map!(
     alm::Array{Alm{ComplexF64,Array{ComplexF64,1}},1},
-    map::PolarizedMap{Float64,RingOrder,Array{Float64,1}},
+    map::PolarizedHealpixMap{Float64,RingOrder,Array{Float64,1}},
 )
     geom_info = Libsharp.make_healpix_geom_info(map.i.resolution.nside, 1)
     alm_info = Libsharp.make_triangular_alm_info(alm[1].lmax, alm[1].mmax, 1)
@@ -345,8 +345,8 @@ are converted to types based on Float64.
 
 # Returns
 
-- `Map{Float64, RingOrder, Array{Float64, 1}}` or
-  `PolarizedMap{Float64, RingOrder, Array{Float64, 1}}` depending on
+- `HealpixMap{Float64, RingOrder, Array{Float64, 1}}` or
+  `PolarizedHealpixMap{Float64, RingOrder, Array{Float64, 1}}` depending on
   if the input alm is of type `Alm{T, Array{T, 1}}` or `Array{Alm{T,
   Array{T, 1}}}` respectively.
 """
@@ -355,7 +355,7 @@ alm2map
 # create a new set of spin-0 maps and project the coefficients to the map
 function alm2map(alm::Alm{ComplexF64,Array{ComplexF64,1}}, nside::Integer)
     npix = nside2npix(nside)
-    map = Map{Float64,RingOrder}(zeros(Float64, npix))
+    map = HealpixMap{Float64,RingOrder}(zeros(Float64, npix))
     alm2map!(alm, map)
     return map
 end
@@ -363,7 +363,7 @@ end
 # create a new set of IQU maps and project the coefficients to the map
 function alm2map(alm::Array{Alm{ComplexF64,Array{ComplexF64,1}},1}, nside::Integer)
     npix = nside2npix(nside)
-    map = PolarizedMap{Float64,RingOrder}(
+    map = PolarizedHealpixMap{Float64,RingOrder}(
         zeros(Float64, npix),
         zeros(Float64, npix),
         zeros(Float64, npix),

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -81,7 +81,7 @@ function applyfullweights!(m::HealpixMap{T,RingOrder}, wgt::Vector{T}) where T
 end
 
 
-function applyfullweights!(m::Map{T,RingOrder}) where T
+function applyfullweights!(m::HealpixMap{T,RingOrder}) where T
     nside = m.resolution.nside
     
     if nside ∈ (32, 64, 128, 256, 512, 1024, 2048)

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -43,7 +43,7 @@ function readfullweights(filename::String)
 end
 
 """
-    applyfullweights!(m::Map{T, RingOrder}, [wgt::Vector{T}]) where T
+    applyfullweights!(m::HealpixMap{T, RingOrder}, [wgt::Vector{T}]) where T
 
 Apply a pixel weighting to a map for more accurate SHTs. Note that 
 this only helps for `lmax<=1.5*Nside`. If this is not the case, the 

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -43,17 +43,17 @@ function readfullweights(filename::String)
 end
 
 """
-    applyweights!(m::Map{T, RingOrder}, wgt::Vector{T}) where T
+    applyweights!(m::HealpixMap{T, RingOrder}, wgt::Vector{T}) where T
 
 Apply a pixel weighting to a map for more accurate SHTs. Note that 
 this only helps for `lmax<=1.5*Nside`. If this is not the case, the 
 pixel weights may do more harm than good.
 
 # Arguments:
-- `m::Map{T, RingOrder}`: map to modify
+- `m::HealpixMap{T, RingOrder}`: map to modify
 - `wgt::Vector{T}`: compressed pixel weights
 """
-function applyweights!(m::Map{T,RingOrder}, wgt::Vector{T}) where T
+function applyweights!(m::HealpixMap{T,RingOrder}, wgt::Vector{T}) where T
     nside = m.resolution.nside
     @assert length(wgt) == n_fullweights(nside)
     pix, vpix = 0, 0
@@ -79,15 +79,15 @@ end
 
 
 """
-    applyweights!(m::PolarizedMap{T, RingOrder}, wgt::Vector{T}) where T
+    applyweights!(m::PolarizedHealpixMap{T, RingOrder}, wgt::Vector{T}) where T
 
 Apply a pixel weighting to a polarized map for more accurate SHTs.
 
 # Arguments:
-- `m::PolarizedMap{T, RingOrder}`: map to modify
+- `m::PolarizedHealpixMap{T, RingOrder}`: map to modify
 - `wgt::Vector{T}`: compressed pixel weights
 """
-function applyweights!(m::PolarizedMap{T,RingOrder}, wgt::Vector{T}) where T
+function applyweights!(m::PolarizedHealpixMap{T,RingOrder}, wgt::Vector{T}) where T
     applyweights!(m.i, wgt)
     applyweights!(m.q, wgt)
     applyweights!(m.u, wgt)

--- a/test/test_conformability.jl
+++ b/test/test_conformability.jl
@@ -1,27 +1,27 @@
 @test Healpix.conformables(
-    Healpix.Map{Int16,Healpix.RingOrder}(4),
-    Healpix.Map{Float32,Healpix.RingOrder}(4),
+    Healpix.HealpixMap{Int16,Healpix.RingOrder}(4),
+    Healpix.HealpixMap{Float32,Healpix.RingOrder}(4),
 )
 @test Healpix.conformables(
-    Healpix.PolarizedMap{Int16,Healpix.RingOrder}(4),
-    Healpix.PolarizedMap{Float32,Healpix.RingOrder}(4),
+    Healpix.PolarizedHealpixMap{Int16,Healpix.RingOrder}(4),
+    Healpix.PolarizedHealpixMap{Float32,Healpix.RingOrder}(4),
 )
 
 # nside mismatch
 @test !Healpix.conformables(
-    Healpix.Map{Int16,Healpix.RingOrder}(8),
-    Healpix.Map{Int16,Healpix.RingOrder}(4),
+    Healpix.HealpixMap{Int16,Healpix.RingOrder}(8),
+    Healpix.HealpixMap{Int16,Healpix.RingOrder}(4),
 )
 @test !Healpix.conformables(
-    Healpix.PolarizedMap{Int16,Healpix.RingOrder}(8),
-    Healpix.PolarizedMap{Int16,Healpix.RingOrder}(4),
+    Healpix.PolarizedHealpixMap{Int16,Healpix.RingOrder}(8),
+    Healpix.PolarizedHealpixMap{Int16,Healpix.RingOrder}(4),
 )
 # order mismatch
 @test !Healpix.conformables(
-    Healpix.Map{Float32,Healpix.RingOrder}(4),
-    Healpix.Map{Float32,Healpix.NestedOrder}(4),
+    Healpix.HealpixMap{Float32,Healpix.RingOrder}(4),
+    Healpix.HealpixMap{Float32,Healpix.NestedOrder}(4),
 )
 @test !Healpix.conformables(
-    Healpix.PolarizedMap{Float32,Healpix.RingOrder}(4),
-    Healpix.PolarizedMap{Float32,Healpix.NestedOrder}(4),
+    Healpix.PolarizedHealpixMap{Float32,Healpix.RingOrder}(4),
+    Healpix.PolarizedHealpixMap{Float32,Healpix.NestedOrder}(4),
 )

--- a/test/test_interp.jl
+++ b/test/test_interp.jl
@@ -807,7 +807,7 @@ compare(Healpix.getringinfo(resol, 15), Healpix.RingInfo(15, 189, 4, 2.937112455
 ################################################################################
 # Map interpolation
 
-m = Healpix.Map{Float64,Healpix.RingOrder}(1)
+m = Healpix.HealpixMap{Float64,Healpix.RingOrder}(1)
 m[:] = 0:11
 @test Healpix.interpolate(m, 0.0500000000, 0.0500000000) ≈ 1.4943231172
 @test Healpix.interpolate(m, 0.5735987756, 0.0500000000) ≈ 1.4348749392

--- a/test/test_mapio.jl
+++ b/test/test_mapio.jl
@@ -1,12 +1,12 @@
 # Map loading
 
 m = Healpix.readMapFromFITS("float_map.fits", 1, Float32)
-@test typeof(m) == Healpix.Map{Float32,Healpix.RingOrder,Array{Float32,1}}
+@test typeof(m) == Healpix.HealpixMap{Float32,Healpix.RingOrder,Array{Float32,1}}
 @test m.resolution.nside == 4
 @test m.pixels == [Float32(x) for x = 0:(12*4^2-1)]
 
 m = Healpix.readMapFromFITS("int_map.fits", 1, Int8)
-@test typeof(m) == Healpix.Map{Int8,Healpix.RingOrder,Array{Int8,1}}
+@test typeof(m) == Healpix.HealpixMap{Int8,Healpix.RingOrder,Array{Int8,1}}
 @test m.resolution.nside == 1
 @test m.pixels == [Int8(x) for x = 0:11]
 
@@ -22,8 +22,8 @@ m2 = Healpix.readMapFromFITS(mapFileName, 1, Int8)
 # Map reordering
 m_ring = Healpix.readMapFromFITS("float_map.fits", 1, Float32)
 m_nest = Healpix.readMapFromFITS("float_map_nest.fits", 1, Float32)
-@test typeof(m_ring) == Healpix.Map{Float32,Healpix.RingOrder,Array{Float32,1}}
-@test typeof(m_nest) == Healpix.Map{Float32,Healpix.NestedOrder,Array{Float32,1}}
+@test typeof(m_ring) == Healpix.HealpixMap{Float32,Healpix.RingOrder,Array{Float32,1}}
+@test typeof(m_nest) == Healpix.HealpixMap{Float32,Healpix.NestedOrder,Array{Float32,1}}
 
 m_converted = Healpix.nest2ring(m_nest)
 @test all(m_converted.pixels .≈ m_ring.pixels)

--- a/test/test_mapiterators.jl
+++ b/test/test_mapiterators.jl
@@ -1,4 +1,4 @@
-m = Healpix.Map{Int8,Healpix.RingOrder}(1)
+m = Healpix.HealpixMap{Int8,Healpix.RingOrder}(1)
 for i = 1:length(m)
     m[i] = i
 end

--- a/test/test_mapmaking.jl
+++ b/test/test_mapmaking.jl
@@ -10,9 +10,9 @@ tod1 = [0.0, 2.5, 1.5, 2.5, 3.5]
 @test binmap1.pixels ≈ [0.0, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 @test hitmap1.pixels == [1, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
-binmap2 = Healpix.Map{Float64,Healpix.RingOrder}(1)
+binmap2 = Healpix.HealpixMap{Float64,Healpix.RingOrder}(1)
 binmap2.pixels = [1.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-hitmap2 = Healpix.Map{Int,Healpix.RingOrder}(1)
+hitmap2 = Healpix.HealpixMap{Int,Healpix.RingOrder}(1)
 hitmap2.pixels = [1, 6, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]
 Healpix.combinemaps!(binmap1, hitmap1, binmap2, hitmap2)
 @test binmap1.pixels ≈ [0.5, 0.5, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/test/test_pixelfunctions.jl
+++ b/test/test_pixelfunctions.jl
@@ -2040,19 +2040,19 @@ end
 
 
 ## Test udgrade
-A = Healpix.Map{Float64, Healpix.NestedOrder}(1.0:Healpix.nside2npix(4))
+A = Healpix.HealpixMap{Float64, Healpix.NestedOrder}(1.0:Healpix.nside2npix(4))
 nest_ref = [8.5,24.5,40.5,56.5,72.5,88.5,104.5,120.5,136.5,152.5,168.5,184.5]
 @test Healpix.udgrade(A, 1).pixels ≈ nest_ref
 @test Healpix.udgrade(A, 8).pixels ≈ repeat(A.pixels, inner=4)
 
 ring_ref = [30.0625,33.4375,36.8125,40.1875,94.75,92.75,96.75,100.75,153.0625,156.4375,
     159.8125,163.1875]
-A = Healpix.Map{Float64, Healpix.RingOrder}(1.0:Healpix.nside2npix(4))
+A = Healpix.HealpixMap{Float64, Healpix.RingOrder}(1.0:Healpix.nside2npix(4))
 @test Healpix.udgrade(A, 1).pixels ≈ ring_ref
 
 
 unseen_ref = [9.0,24.5,40.5,56.5,72.5,88.5,104.5,120.5,136.5,152.5,168.5,184.5]
-A = Healpix.Map{Float64, Healpix.NestedOrder}(1.0:Healpix.nside2npix(4))
+A = Healpix.HealpixMap{Float64, Healpix.NestedOrder}(1.0:Healpix.nside2npix(4))
 A[1] = Healpix.UNSEEN
 Healpix.udgrade(A, 1).pixels
 @test Healpix.udgrade(A, 1).pixels ≈ unseen_ref

--- a/test/test_polarizedmap.jl
+++ b/test/test_polarizedmap.jl
@@ -3,23 +3,23 @@ pixels_nside2 = collect(1:(12*2^2))
 pixels_nside4 = collect(1:(12*4^2))
 
 polmap =
-    Healpix.PolarizedMap{Int,Healpix.RingOrder}(pixels_nside1, pixels_nside1, pixels_nside1)
+    Healpix.PolarizedHealpixMap{Int,Healpix.RingOrder}(pixels_nside1, pixels_nside1, pixels_nside1)
 @test polmap.i == pixels_nside1
 @test polmap.q == pixels_nside1
 @test polmap.u == pixels_nside1
 
 # test the untyped constructor
-polmap_new = Healpix.PolarizedMap(polmap.i, polmap.q, polmap.u)
+polmap_new = Healpix.PolarizedHealpixMap(polmap.i, polmap.q, polmap.u)
 @test polmap.i == polmap_new.i
 @test polmap.q == polmap_new.q
 @test polmap.u == polmap_new.u
 
-polmap = Healpix.PolarizedMap{Int8,Healpix.RingOrder}(128)
+polmap = Healpix.PolarizedHealpixMap{Int8,Healpix.RingOrder}(128)
 
 @test length(polmap.i) == length(polmap.q) == length(polmap.u)
 @test length(polmap.i) == Healpix.nside2npix(128)
 
-@test_throws ArgumentError("The three I/Q/U vectors must have the same resolution") Healpix.PolarizedMap{
+@test_throws ArgumentError("The three I/Q/U vectors must have the same resolution") Healpix.PolarizedHealpixMap{
     Int,
     Healpix.RingOrder,
 }(

--- a/test/test_projections.jl
+++ b/test/test_projections.jl
@@ -1,4 +1,4 @@
-m = Healpix.Map{Float64,Healpix.RingOrder}(1)
+m = Healpix.HealpixMap{Float64,Healpix.RingOrder}(1)
 m.pixels = 1.0:12.0
 
 # Do not run @test here, just check that the function can be ran

--- a/test/test_sphtfunc.jl
+++ b/test/test_sphtfunc.jl
@@ -4,7 +4,7 @@ using Test
 ## spin 0 map2alm
 nside = 4
 lmax = 4
-map = Healpix.Map{Float64,Healpix.RingOrder}(2 .* ones(Healpix.nside2npix(nside)))
+map = Healpix.HealpixMap{Float64,Healpix.RingOrder}(2 .* ones(Healpix.nside2npix(nside)))
 alm = Healpix.map2alm(map, lmax = lmax, mmax = lmax, niter = 0)
 
 test_alm_spin0 = [
@@ -33,12 +33,12 @@ test_alm_spin0 = [
 )
 
 ## test type convert
-map_int = Healpix.Map{Int64,Healpix.RingOrder}(2 .* ones(Int64, Healpix.nside2npix(nside)))
+map_int = Healpix.HealpixMap{Int64,Healpix.RingOrder}(2 .* ones(Int64, Healpix.nside2npix(nside)))
 alm = Healpix.map2alm(map_int, lmax = lmax, mmax = lmax, niter = 0)
 @test isapprox(alm.alm, test_alm_spin0)
 
 ## spin 0 map2alm niter=3
-map = Healpix.Map{Float64,Healpix.RingOrder}(2 .* ones(Healpix.nside2npix(nside)))
+map = Healpix.HealpixMap{Float64,Healpix.RingOrder}(2 .* ones(Healpix.nside2npix(nside)))
 alm_niter_3 = Healpix.map2alm(map, lmax = lmax, mmax = lmax, niter = 3).alm
 alm_niter_0 = Healpix.map2alm(map, lmax = lmax, mmax = lmax, niter = 0).alm
 reference_Δ = [
@@ -127,7 +127,7 @@ map_bf = Healpix.alm2map(alm, nside)
 ## spin 2 map2alm
 nside = 4
 lmax = 4
-map = Healpix.PolarizedMap{Float64,Healpix.RingOrder}(
+map = Healpix.PolarizedHealpixMap{Float64,Healpix.RingOrder}(
     2 .* ones(Healpix.nside2npix(nside)),
     2 .* ones(Healpix.nside2npix(nside)),
     2 .* ones(Healpix.nside2npix(nside)),
@@ -155,7 +155,7 @@ test_alm_spin2 = [
 @test isapprox(alms[3].alm, test_alm_spin2)
 
 ## test type convert
-map_int = Healpix.PolarizedMap{BigFloat,Healpix.RingOrder}(
+map_int = Healpix.PolarizedHealpixMap{BigFloat,Healpix.RingOrder}(
     2 .* ones(BigFloat, Healpix.nside2npix(nside)),
     2 .* ones(BigFloat, Healpix.nside2npix(nside)),
     2 .* ones(BigFloat, Healpix.nside2npix(nside)),
@@ -315,7 +315,7 @@ maps_float = Healpix.alm2map([alm_t, alm_e, alm_b], nside)
 
 ## test alm2cl
 nside = 4
-map = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
+map = Healpix.HealpixMap{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
 alm = Healpix.map2alm(map)
 testcl = [
     1.25640233e+01,
@@ -337,7 +337,7 @@ testcl = [
 ## test ringweights
 nside = 32
 compressed_weights = Healpix.readfullweights("healpix_full_weights_nside_$(lpad(nside,4,'0')).fits")
-m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
+m = Healpix.HealpixMap{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
 Healpix.applyweights!(m, compressed_weights)
 alm = Healpix.map2alm(m; niter=0)
 ref_alm = [
@@ -357,7 +357,7 @@ ref_alm = [
 ## test polarized map pixel weights
 nside = 32
 npix = Healpix.nside2npix(nside)
-m = Healpix.PolarizedMap{Float64, Healpix.RingOrder}(
+m = Healpix.PolarizedHealpixMap{Float64, Healpix.RingOrder}(
     1.0 .* collect(1:npix), 
     1.0 .* collect(1:npix), 
     1.0 .* collect(1:npix))

--- a/test/test_sphtfunc.jl
+++ b/test/test_sphtfunc.jl
@@ -355,7 +355,7 @@ ref_alm = [
 @test isapprox(alm.alm[1:10], ref_alm)
 
 # test artifact 
-m = Healpix.Map{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
+m = Healpix.HealpixMap{Float64,Healpix.RingOrder}(ones(Healpix.nside2npix(nside)))
 Healpix.applyfullweights!(m)
 alm = Healpix.map2alm(m; niter=0)
 @test isapprox(alm.alm[1:10], ref_alm)
@@ -387,7 +387,7 @@ ref_b = [     0.        ,      0.        , -19883.86722869,
 @test e.alm[1:10] ≈ ref_e
 @test b.alm[1:10] ≈ ref_b
 
-m = Healpix.PolarizedMap{Float64, Healpix.RingOrder}(
+m = Healpix.PolarizedHealpixMap{Float64, Healpix.RingOrder}(
     1.0 .* collect(1:npix), 
     1.0 .* collect(1:npix), 
     1.0 .* collect(1:npix))


### PR DESCRIPTION
Following issue #43, this PR makes the following **breaking** changes:

- Rename `GenericMap` to `AbstractHealpixMap`
- Rename `Map` to `HealpixMap`
- Rename `PolarizedMap` to `PolarizedHealpixMap`

