### PR TITLE
Test Julia 1.7

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.3', '1.6', 'nightly']
+        julia-version: ['1.3', '1.6', '1.7', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         arch:
           - x64


### PR DESCRIPTION
Now that Julia 1.7.0 has been released, it's time to update our build scripts. I chose to keep the tests for Julia 1.6, as this is going to become the new LTS release. As a result, the number of elements in the test matrix has increased, as with this PR we test 1.3, 1.6, 1.7, and `nightly`.

I will open an issue to discuss whether we feel the need to continue supporting Julia 1.3, or if we can drop it.
