### PR TITLE
Update NSIDE_MAX

### DIFF
--- a/src/nside.jl
+++ b/src/nside.jl
@@ -4,7 +4,7 @@
 Maximum allowed value for the NSIDE resolution parameter.
 
 """
-const NSIDE_MAX = 8192
+const NSIDE_MAX = 16384
 
 ########################################################################
 

--- a/src/nside.jl
+++ b/src/nside.jl
@@ -4,7 +4,7 @@
 Maximum allowed value for the NSIDE resolution parameter.
 
 """
-const NSIDE_MAX = 16384
+const NSIDE_MAX = 32768
 
 ########################################################################
 

--- a/src/nside.jl
+++ b/src/nside.jl
@@ -4,7 +4,7 @@
 Maximum allowed value for the NSIDE resolution parameter.
 
 """
-const NSIDE_MAX = 2^(floor(Int, 0.5 * ((sizeof(Int) * 8 - 1) - log2(12))))
+const NSIDE_MAX = 2^floor(Int, 0.5 * log2(typemax(Int32) / 12))
 
 ########################################################################
 

--- a/src/nside.jl
+++ b/src/nside.jl
@@ -4,7 +4,7 @@
 Maximum allowed value for the NSIDE resolution parameter.
 
 """
-const NSIDE_MAX = 32768
+const NSIDE_MAX = 2^(floor(Int, 0.5 * ((sizeof(Int) * 8 - 1) - log2(12))))
 
 ########################################################################
 

--- a/src/nside.jl
+++ b/src/nside.jl
@@ -1,10 +1,10 @@
 @doc raw"""
     NSIDE_MAX
 
-Maximum allowed value for the NSIDE resolution parameter.
+Maximum allowed value for the NSIDE resolution parameter, depending on system Int size
 
 """
-const NSIDE_MAX = 2^floor(Int, 0.5 * log2(typemax(Int32) / 12))
+const NSIDE_MAX = 2^floor(Int, 0.5 * log2(typemax(Int) / 12))
 
 ########################################################################
 


### PR DESCRIPTION
I am using this for a photometry project where the base resolution of the images is 0.26 arcsec (2k x 4k detectors). So, reasonable maps really need at least NSIDE = 2^14 in order to visualize CCD scale features. It is not obvious how to increase NSIDE_MAX from the user side? If it is easy to change, maybe adding to the docs to tell users how to do this would be sufficient. Otherwise, I would appreciate merging this PR to increase the max to at least 2^15. The code seems to have been written well enough that it generalizes just fine and nothing breaks when I changed this on my fork. However, let me know if there is some functionality I missed that I would need to edit to enable this change.