### PR TITLE
Use a more robust algorithm for vec2ang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Use a more accurate algorithm for `vec2ang` [#76][https://github.com/ziotom78/Healpix.jl/pull/76]
+
 -   Make `NSIDE_MAX` dependent on the architecture (32/64 bit) of the system [#75](https://github.com/ziotom78/Healpix.jl/pull/75)
 
 # Version 3.0.1

--- a/src/pixelfunc.jl
+++ b/src/pixelfunc.jl
@@ -239,14 +239,13 @@ and the longitude `phi` (in radians) of the direction in the sky the vector is
 pointing at.
 """
 function vec2ang(x, y, z)
-    norm = sqrt(x^2 + y^2 + z^2)
-    theta = acos(z / norm)
+    theta = atan(sqrt(x^2 + y^2), z)
     phi = atan(y, x)
     if phi < 0
         phi += 2π
     end
 
-    return (theta, phi)
+    (theta, phi)
 end
 
 ################################################################################

--- a/test/test_pixelfunctions.jl
+++ b/test/test_pixelfunctions.jl
@@ -92,6 +92,11 @@ theta, phi = Healpix.vec2ang(2.922856075911509, 2.304551510739625, 0.87468748910
 @test theta ≈ 1.339986032596264 atol = eps
 @test phi ≈ 0.667663882320130 atol = eps
 
+# Additional test near the poles
+theta, phi = Healpix.vec2ang(2.2360679458796287e-05, 2.2360679458796287e-05, 0.999999999)
+@test theta ≈ 3.1622776175589035e-05
+@test phi ≈ 0.7853981633974483
+
 # ang2pixNest
 
 @test_throws DomainError(0) Healpix.Resolution(0)


### PR DESCRIPTION
As discussed in [the `litebird_sim` repo](https://github.com/litebird/litebird_sim/pull/164#discussion_r860563670), we are using a numerically unstable implementation of `vec2ang`. This PR implements the same formula as [`ducc0`](https://gitlab.mpcdf.mpg.de/mtr/ducc/-/blob/ducc0/src/ducc0/math/pointing.cc#L46), which is more accurate near the poles. A new test has been added as well.
