### PR TITLE
Add Base.parent to HealpixMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Implement `Base.parent` for `HealpixMap` which returns the underlying array
+
 -   **Breaking change**: `udgrade` now always assumes `pess = false` [#72](https://github.com/ziotom78/Healpix.jl/pull/72)
 
 -   Use a more accurate algorithm for `vec2ang` [#76][https://github.com/ziotom78/Healpix.jl/pull/76]

--- a/src/map.jl
+++ b/src/map.jl
@@ -141,7 +141,7 @@ import Base: +, -, *, /
 # Iterator interface
 
 Base.size(m::HealpixMap{T,O,AA}) where {T,O,AA} = (m.resolution.numOfPixels,)
-
+Base.parent(m::HealpixMap) = m.pixels
 Base.IndexStyle(::Type{<:HealpixMap{T,O,AA}}) where {T,O,AA} = IndexLinear()
 
 function getindex(m::HealpixMap{T,O,AA}, i::Integer) where {T,O,AA}


### PR DESCRIPTION
This adds the standard method `parent` for a `HealpixMap`, which yields the parent array.