### PR TITLE
Add checks for θ in ang2pix* functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add checks for colatitude θ in functions that take angles as input [#84](https://github.com/ziotom78/Healpix.jl/pull/84)
+
 # Version 4.0.0
 
 -   **Breaking change**: `udgrade` now always assumes `pess = false` [#72](https://github.com/ziotom78/Healpix.jl/pull/72)

--- a/src/pixelfunc.jl
+++ b/src/pixelfunc.jl
@@ -150,6 +150,8 @@ pixel indexes are 1-based (this is Julia)!
 """
 function ang2pixNest(resol::Resolution, theta, phi)
 
+    (0 ≤ theta ≤ π) || throw(DomainError(theta, "Invalid value of theta"))
+    
     nside = resol.nside
     local ix, iy, face_num
 
@@ -284,6 +286,8 @@ indexes are 1-based (this is Julia)!
 """
 function ang2pixRing(resol::Resolution, theta, phi)
 
+    (0 ≤ theta ≤ π) || throw(DomainError(theta, "Invalid value of theta"))
+    
     z = cos(theta)
     z_abs = abs(z)
 

--- a/test/test_pixelfunctions.jl
+++ b/test/test_pixelfunctions.jl
@@ -50,6 +50,9 @@ x, y, z = Healpix.ang2vec(0.637907993514304, 4.877925523463614)
 @test y ≈ -0.587375491097860 atol = eps
 @test z ≈ 0.803343338527719 atol = eps
 
+@test_throws DomainError(-1.0, "Invalid value of theta") Healpix.ang2vec(-1.0, 0.0)
+@test_throws DomainError(4.0, "Invalid value of theta") Healpix.ang2vec(4.0, 0.0)
+
 # vec2ang
 
 theta, phi = Healpix.vec2ang(2.479973695958578, 2.540405094768749, 1.360043653263107)
@@ -148,6 +151,8 @@ highresol = Healpix.Resolution(2^29)
 @test Healpix.ang2pixNest(resol, 3.1415926535897931, 5.0265482457436690) == 720897
 @test Healpix.ang2pixNest(resol, 3.1415926535897931, 6.2831853071795862) == 720897
 
+@test_throws DomainError(-1.0, "Invalid value of theta") Healpix.ang2pixNest(resol, -1.0, 0.0)
+@test_throws DomainError(4.0, "Invalid value of theta") Healpix.ang2pixNest(resol, 4.0, 0.0)
 
 @test Healpix.ang2pixNest(highresol, 1.570796325553133199, 0.785398163397448279) == 1
 @test Healpix.ang2pixNest(highresol, 1.570796324311369840, 0.785398164860366288) == 2
@@ -238,6 +243,9 @@ highresol = Healpix.Resolution(2^29)
 @test Healpix.ang2pixRing(resol, 3.1415926535897931, 3.7699111843077517) == 786431
 @test Healpix.ang2pixRing(resol, 3.1415926535897931, 5.0265482457436690) == 786432
 @test Healpix.ang2pixRing(resol, 3.1415926535897931, 6.2831853071795862) == 786429
+
+@test_throws DomainError(-1.0, "Invalid value of theta") Healpix.ang2pixNest(resol, -1.0, 0.0)
+@test_throws DomainError(4.0, "Invalid value of theta") Healpix.ang2pixNest(resol, 4.0, 0.0)
 
 @test Healpix.ang2pixRing(highresol, 0.000000001520843396, 0.785398163397448279) == 1
 @test Healpix.ang2pixRing(highresol, 0.000000001520843396, 2.356194490192344837) == 2


### PR DESCRIPTION
This should fix issue #83. Note that, unlike [healpy](https://github.com/healpy/healpy/blob/9c42baa8f27b402cb6242d05a61087e5b4fb42d2/healpy/pixelfunc.py#L156), we do not tolerate slight deviations over π
