### PR TITLE
[CI] Run tests on latest stable version and add timeout

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -11,10 +11,11 @@ on:
 jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.3', '1.7', 'nightly']
+        julia-version: ['1.3', '1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         arch:
           - x64

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -21,7 +21,7 @@ jobs:
           - x64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
@@ -29,21 +29,11 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: "Cache artifacts"
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-
+        uses: julia-actions/cache@v1
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - name: "Run unit tests"
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@v1
 
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
With `'1'` instead of `'1.7'` you don't have to update the list of versions every time a new version of Julia is out.  Also, tests on Julia nightly are currently stalling, but the default timeout is 6 hours which is pretty much non-sense and also a huge overkill for this package which takes 2-3 minutes at most to run a full job.  15 minutes should be a much more reasonable timeout