### PR TITLE
alm: make `each_ell_m()` type stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Fix a type stability bug [#125](https://github.com/ziotom78/Healpix.jl/pull/125) [thanks to @hsgg]
+
 # Version 4.2.2
 
 -   Fix bug [#112](https://github.com/ziotom78/Healpix.jl/issues/112)

--- a/src/alm.jl
+++ b/src/alm.jl
@@ -225,7 +225,7 @@ end
     m-major order (the same order as how the harmonic coefficients are stored in `Alm` objects).
 """
 function each_ell_m(alm::Alm{Complex{T}}) where {T <: Number}
-    ell_m = Vector(undef, numberOfAlms(alm.lmax, alm.mmax))
+    ell_m = Vector{Tuple{Int,Int}}(undef, numberOfAlms(alm.lmax, alm.mmax))
     i = 1
     for m in 0:alm.mmax
         for l in each_ell(alm, m)


### PR DESCRIPTION
I ran into a performance problem where `each_ell_m` is used in a loop. Since it gave a type unstable vector back, the performance was not great. This fixes this (gives a 3x speed up!).