### PR TITLE
Update julia versions for testing in UnitTests.yml

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.3', '1']
+        julia-version: ['min', 'lts', '1']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         arch: [x64]
     steps:


### PR DESCRIPTION
- Instead of '1.3', use 'min' to make julia-actions/setup-julia read the Project.toml file and select a version
- Add testing on current LTS release